### PR TITLE
Deselecting all permissions/flags only deselecting one before throwing error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
+
+## [Unreleased]
+
+### Fixed
+- GUIs consuming items placed into them.
+- Deselecting all permissions/flags only deselecting one before throwing error.
+
+## [0.1.0]
+- Initial Pre-Release for Minecraft 1.20. Watch out for bugs!

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/persistence/claims/ClaimFlagRepositorySQLite.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/persistence/claims/ClaimFlagRepositorySQLite.kt
@@ -20,7 +20,7 @@ class ClaimFlagRepositorySQLite(private val storage: SQLiteStorage): ClaimFlagRe
     }
 
     override fun getByClaim(claim: Claim): Set<Flag> {
-        return rules[claim.id] ?: mutableSetOf()
+        return rules[claim.id]?.toSet() ?: mutableSetOf()
     }
 
     override fun add(claim: Claim, rule: Flag) {

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/persistence/claims/ClaimFlagRepositorySQLite.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/persistence/claims/ClaimFlagRepositorySQLite.kt
@@ -23,26 +23,26 @@ class ClaimFlagRepositorySQLite(private val storage: SQLiteStorage): ClaimFlagRe
         return rules[claim.id]?.toSet() ?: mutableSetOf()
     }
 
-    override fun add(claim: Claim, rule: Flag) {
-        rules.getOrPut(claim.id) { mutableSetOf() }.add(rule)
+    override fun add(claim: Claim, flag: Flag) {
+        rules.getOrPut(claim.id) { mutableSetOf() }.add(flag)
         try {
             storage.connection.executeUpdate("INSERT INTO claimRules (claimId, rule) VALUES (?,?)",
-                claim.id, rule.name)
+                claim.id, flag.name)
         } catch (error: SQLException) {
             error.printStackTrace()
         }
     }
 
-    override fun remove(claim: Claim, rule: Flag) {
+    override fun remove(claim: Claim, flag: Flag) {
         val claimRules = rules[claim.id] ?: return
-        claimRules.remove(rule)
+        claimRules.remove(flag)
         if (claimRules.isEmpty()) {
             rules.remove(claim.id)
         }
 
         try {
             storage.connection.executeUpdate("DELETE FROM claimRules WHERE claimId=? AND rule=?",
-                claim.id, rule.name)
+                claim.id, flag.name)
         } catch (error: SQLException) {
             error.printStackTrace()
         }

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/persistence/claims/ClaimPermissionRepositorySQLite.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/persistence/claims/ClaimPermissionRepositorySQLite.kt
@@ -19,8 +19,8 @@ class ClaimPermissionRepositorySQLite(private val storage: SQLiteStorage): Claim
         return permissions[claim.id]?.contains(permission) ?: false
     }
 
-    override fun getByClaim(claim: Claim): MutableSet<ClaimPermission> {
-        return permissions[claim.id] ?: mutableSetOf()
+    override fun getByClaim(claim: Claim): Set<ClaimPermission> {
+        return permissions[claim.id]?.toSet() ?: setOf()
     }
 
     override fun add(claim: Claim, permission: ClaimPermission) {

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/persistence/claims/PlayerAccessRepositorySQLite.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/persistence/claims/PlayerAccessRepositorySQLite.kt
@@ -16,12 +16,12 @@ class PlayerAccessRepositorySQLite(private val storage: SQLiteStorage): PlayerAc
         preload()
     }
 
-    override fun getByClaim(claim: Claim): MutableMap<UUID, MutableSet<ClaimPermission>> {
-        return playerAccess[claim.id] ?: mutableMapOf()
+    override fun getByClaim(claim: Claim): Map<UUID, Set<ClaimPermission>> {
+        return playerAccess[claim.id]?.toMap() ?: emptyMap()
     }
 
-    override fun getByPlayer(claim: Claim, player: OfflinePlayer): MutableSet<ClaimPermission> {
-        return playerAccess[claim.id]?.get(player.uniqueId) ?: mutableSetOf()
+    override fun getByPlayer(claim: Claim, player: OfflinePlayer): Set<ClaimPermission> {
+        return playerAccess[claim.id]?.get(player.uniqueId)?.toSet() ?: emptySet()
     }
 
     override fun add(claim: Claim, player: OfflinePlayer, permission: ClaimPermission) {

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/PlayerPermissionServiceImpl.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/PlayerPermissionServiceImpl.kt
@@ -49,7 +49,7 @@ class PlayerPermissionServiceImpl(private val playerAccessRepo: PlayerAccessRepo
     }
 
     override fun removeAllForPlayer(claim: Claim, player: OfflinePlayer): PlayerPermissionChangeResult {
-        val permissionsToRemove = getByPlayer(claim, player)
+        val permissionsToRemove = getByPlayer(claim, player).toSet()
         if (permissionsToRemove.isEmpty()) return PlayerPermissionChangeResult.UNCHANGED
 
         for (permission in permissionsToRemove) {

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/PlayerPermissionServiceImpl.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/PlayerPermissionServiceImpl.kt
@@ -49,7 +49,7 @@ class PlayerPermissionServiceImpl(private val playerAccessRepo: PlayerAccessRepo
     }
 
     override fun removeAllForPlayer(claim: Claim, player: OfflinePlayer): PlayerPermissionChangeResult {
-        val permissionsToRemove = getByPlayer(claim, player).toSet()
+        val permissionsToRemove = getByPlayer(claim, player)
         if (permissionsToRemove.isEmpty()) return PlayerPermissionChangeResult.UNCHANGED
 
         for (permission in permissionsToRemove) {


### PR DESCRIPTION
This was due to the reference being passed from the repository rather than the value, causing a concurrent modification error as the loop attempts to keep going while the set it is looping through is being modified.

A changelog file has also been provided to keep track of changes before it gets confusing.