### PR TITLE
Visualiser not updating when changing edit tool mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ### Fixed
 - GUIs consuming items placed into them.
 - Deselecting all permissions/flags only deselecting one before throwing error.
+- Visualiser not updating when changing edit tool mode.
 
 ## [0.1.0]
 - Initial Pre-Release for Minecraft 1.20. Watch out for bugs!

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolListener.kt
@@ -49,7 +49,7 @@ class EditToolListener(private val claims: ClaimRepository,
         if (event.hand == EquipmentSlot.OFF_HAND) {
             val location = event.clickedBlock?.location ?: return
             val partition: Partition? = partitionService.getByLocation(location)
-            EditToolMenu(claimService, partitionService, playerStateService, event.player, partition)
+            EditToolMenu(claimService, partitionService, playerStateService, event.player, visualiser, partition)
                 .openEditToolMenu()
             return
         }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/EditToolMenu.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/EditToolMenu.kt
@@ -12,12 +12,13 @@ import dev.mizarc.bellclaims.api.PartitionService
 import dev.mizarc.bellclaims.api.PlayerStateService
 import dev.mizarc.bellclaims.api.events.PartitionModificationEvent
 import dev.mizarc.bellclaims.domain.partitions.Partition
+import dev.mizarc.bellclaims.interaction.visualisation.Visualiser
 import dev.mizarc.bellclaims.utils.lore
 import dev.mizarc.bellclaims.utils.name
 
 class EditToolMenu(private val claimService: ClaimService, private val partitionService: PartitionService,
                    private val playerStateService: PlayerStateService, private val player: Player,
-                   private val partition: Partition? = null) {
+                   private val visualiser: Visualiser, private val partition: Partition? = null) {
     fun openEditToolMenu() {
         val gui = ChestGui(1, "Claim Tool")
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
@@ -36,6 +37,7 @@ class EditToolMenu(private val claimService: ClaimService, private val partition
             modeSwitchItem.lore("Edit Mode")
             guiModeSwitchItem = GuiItem(modeSwitchItem) {
                 playerState.claimToolMode = 1
+                visualiser.refresh(player)
                 openEditToolMenu()
             }
         }
@@ -44,6 +46,7 @@ class EditToolMenu(private val claimService: ClaimService, private val partition
             modeSwitchItem.lore("> Edit Mode")
             guiModeSwitchItem = GuiItem(modeSwitchItem) {
                 playerState.claimToolMode = 0
+                visualiser.refresh(player)
                 openEditToolMenu()
             }
         }


### PR DESCRIPTION
Simply just needed to call the visualiser refresh method when clicking the button.