### PR TITLE
Reconfigure project to only require Vault as a soft dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [Unreleased]
+
+## Changed
+- Vault dependency is now optional. Without Vault and a compatible chat metadata provider, player limits are handled solely through the config.
+
 ## [0.1.1]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -17,8 +17,13 @@ Beta. Safe to run on testing servers, but would not recommend for production due
 ## Installation
 Download the latest release (.jar file) from the releases tab and place it in your server's plugins folder. 
 
+For additional functionality such as per player/rank permissions and claim limits, you must install 
+[Vault](https://www.spigotmc.org/resources/vault.34315/) as well as a compatible permission and chat
+metadata provider. [LuckPerms](https://luckperms.net/) is a recommended plugin for handling both.
+
 ## Getting Started
-To establish a claim, place down a bell and shift right click it. This opens up a creation menu where you are able to name your claim. Once the claim is established, you will be presented with various options to do with claim management.
+To establish a claim, place down a bell and shift right click it. This opens up a creation menu where you are able to 
+name your claim. Once the claim is established, you will be presented with various options to do with claim management.
 
 ## Permissions
 ### Recommended User Permissions

--- a/README.md
+++ b/README.md
@@ -47,6 +47,23 @@ name your claim. Once the claim is established, you will be presented with vario
 ### Recommended Moderation Permissions
 - bellclaims.command.claimoverride - Allows use of the `claimoverride` command bypass claim protections.
 
+## Per Player Claims Limits
+Ensure that you have a Vault provider installed to set limits as described out in the installation section. Each Vault 
+provider plugin has its own way of implementing this feature. As LuckPerms is the recommended provider, instructions 
+will make use of it as such.
+
+To set a metadata for a player, use command:
+
+`/lp group <player_name> meta set <limit_name> <desired_number>`
+
+For groups:
+
+`/lp user <group_name> meta set <limit_name> <desired_number>`
+
+Here are the different limits you can set:
+- bellclaims.claim_limit - Defines how many claim bells the player can own.
+- bellclaims.claim_block_limit - Defines how many blocks the player's claims can occupy in total.
+
 ## Building from Source
 ### Requirements
 - Java JDK 17 or newer

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/playerlimit/SimplePlayerLimitServiceImpl.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/playerlimit/SimplePlayerLimitServiceImpl.kt
@@ -1,0 +1,39 @@
+package dev.mizarc.bellclaims.infrastructure.services.playerlimit
+
+import dev.mizarc.bellclaims.api.PlayerLimitService
+import dev.mizarc.bellclaims.domain.claims.ClaimRepository
+import dev.mizarc.bellclaims.domain.partitions.PartitionRepository
+import dev.mizarc.bellclaims.infrastructure.persistence.Config
+import org.bukkit.OfflinePlayer
+
+class SimplePlayerLimitServiceImpl(private val config: Config, private val claimRepo: ClaimRepository,
+                                   private val partitionRepo: PartitionRepository): PlayerLimitService {
+    override fun getTotalClaimCount(player: OfflinePlayer): Int {
+        return config.claimLimit
+    }
+
+    override fun getTotalClaimBlockCount(player: OfflinePlayer): Int {
+        return config.claimBlockLimit
+    }
+
+    override fun getUsedClaimsCount(player: OfflinePlayer): Int {
+        return claimRepo.getByPlayer(player).count()
+    }
+
+    override fun getUsedClaimBlockCount(player: OfflinePlayer): Int {
+        val claims = claimRepo.getByPlayer(player)
+        val count = claims.sumOf { claim ->
+            val partitions = partitionRepo.getByClaim(claim)
+            partitions.sumOf { partition -> partition.getBlockCount() }
+        }
+        return count
+    }
+
+    override fun getRemainingClaimCount(player: OfflinePlayer): Int {
+        return getTotalClaimCount(player) - getUsedClaimsCount(player)
+    }
+
+    override fun getRemainingClaimBlockCount(player: OfflinePlayer): Int {
+        return getTotalClaimBlockCount(player) - getUsedClaimBlockCount(player)
+    }
+}

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/playerlimit/SimplePlayerLimitServiceImpl.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/playerlimit/SimplePlayerLimitServiceImpl.kt
@@ -9,11 +9,11 @@ import org.bukkit.OfflinePlayer
 class SimplePlayerLimitServiceImpl(private val config: Config, private val claimRepo: ClaimRepository,
                                    private val partitionRepo: PartitionRepository): PlayerLimitService {
     override fun getTotalClaimCount(player: OfflinePlayer): Int {
-        return config.claimLimit
+        return config.claimLimit.coerceAtLeast(0)
     }
 
     override fun getTotalClaimBlockCount(player: OfflinePlayer): Int {
-        return config.claimBlockLimit
+        return config.claimBlockLimit.coerceAtLeast(0)
     }
 
     override fun getUsedClaimsCount(player: OfflinePlayer): Int {

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/playerlimit/VaultPlayerLimitServiceImpl.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/playerlimit/VaultPlayerLimitServiceImpl.kt
@@ -1,4 +1,4 @@
-package dev.mizarc.bellclaims.infrastructure.services
+package dev.mizarc.bellclaims.infrastructure.services.playerlimit
 
 import dev.mizarc.bellclaims.api.PlayerLimitService
 import dev.mizarc.bellclaims.domain.claims.ClaimRepository
@@ -8,9 +8,9 @@ import net.milkbowl.vault.chat.Chat
 import org.bukkit.Bukkit
 import org.bukkit.OfflinePlayer
 
-class PlayerLimitServiceImpl(private val config: Config, private val metadata: Chat,
-                             private val claimRepo: ClaimRepository,
-                             private val partitionRepo: PartitionRepository): PlayerLimitService {
+class VaultPlayerLimitServiceImpl(private val config: Config, private val metadata: Chat,
+                                  private val claimRepo: ClaimRepository,
+                                  private val partitionRepo: PartitionRepository): PlayerLimitService {
     override fun getTotalClaimCount(player: OfflinePlayer): Int {
         return metadata.getPlayerInfoInteger(
             Bukkit.getServer().worlds[0].name, player,
@@ -29,12 +29,9 @@ class PlayerLimitServiceImpl(private val config: Config, private val metadata: C
 
     override fun getUsedClaimBlockCount(player: OfflinePlayer): Int {
         val claims = claimRepo.getByPlayer(player)
-        var count = 0
-        for (claim in claims) {
+        val count = claims.sumOf { claim ->
             val partitions = partitionRepo.getByClaim(claim)
-            for (partition in partitions) {
-                count += partition.getBlockCount()
-            }
+            partitions.sumOf { partition -> partition.getBlockCount() }
         }
         return count
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,3 +2,4 @@ name: BellClaims
 version: 1.0
 api-version: '1.20'
 main: dev.mizarc.bellclaims.BellClaims
+softdepend: [Vault]

--- a/src/test/kotlin/dev/mizarc/bellclaims/infrastructure/services/PlayerLimitServiceImplTest.kt
+++ b/src/test/kotlin/dev/mizarc/bellclaims/infrastructure/services/PlayerLimitServiceImplTest.kt
@@ -6,6 +6,7 @@ import dev.mizarc.bellclaims.domain.claims.ClaimRepository
 import dev.mizarc.bellclaims.domain.partitions.*
 import dev.mizarc.bellclaims.domain.players.PlayerStateRepository
 import dev.mizarc.bellclaims.infrastructure.persistence.Config
+import dev.mizarc.bellclaims.infrastructure.services.playerlimit.VaultPlayerLimitServiceImpl
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -49,7 +50,7 @@ class PlayerLimitServiceImplTest {
         playerStateRepo = mockk()
         claimRepo = mockk()
         partitionRepo = mockk()
-        playerLimitService = PlayerLimitServiceImpl(config, metadata, claimRepo, partitionRepo)
+        playerLimitService = VaultPlayerLimitServiceImpl(config, metadata, claimRepo, partitionRepo)
 
         playerOne = mockk<OfflinePlayer>()
         uuidOne = UUID.fromString("22d7b7e7-7773-4f78-8e0b-817960fba37a")

--- a/src/test/kotlin/dev/mizarc/bellclaims/infrastructure/services/playerlimit/SimplePlayerLimitServiceImplTest.kt
+++ b/src/test/kotlin/dev/mizarc/bellclaims/infrastructure/services/playerlimit/SimplePlayerLimitServiceImplTest.kt
@@ -1,4 +1,4 @@
-package dev.mizarc.bellclaims.infrastructure.services
+package dev.mizarc.bellclaims.infrastructure.services.playerlimit
 
 import dev.mizarc.bellclaims.api.PlayerLimitService
 import dev.mizarc.bellclaims.domain.claims.Claim
@@ -6,7 +6,6 @@ import dev.mizarc.bellclaims.domain.claims.ClaimRepository
 import dev.mizarc.bellclaims.domain.partitions.*
 import dev.mizarc.bellclaims.domain.players.PlayerStateRepository
 import dev.mizarc.bellclaims.infrastructure.persistence.Config
-import dev.mizarc.bellclaims.infrastructure.services.playerlimit.VaultPlayerLimitServiceImpl
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -19,7 +18,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.*
 
-class PlayerLimitServiceImplTest {
+class SimplePlayerLimitServiceImplTest {
     private lateinit var config: Config
     private lateinit var metadata: Chat
     private lateinit var playerStateRepo: PlayerStateRepository
@@ -50,7 +49,7 @@ class PlayerLimitServiceImplTest {
         playerStateRepo = mockk()
         claimRepo = mockk()
         partitionRepo = mockk()
-        playerLimitService = VaultPlayerLimitServiceImpl(config, metadata, claimRepo, partitionRepo)
+        playerLimitService = SimplePlayerLimitServiceImpl(config, claimRepo, partitionRepo)
 
         playerOne = mockk<OfflinePlayer>()
         uuidOne = UUID.fromString("22d7b7e7-7773-4f78-8e0b-817960fba37a")
@@ -83,12 +82,8 @@ class PlayerLimitServiceImplTest {
     @Test
     fun `getTotalClaimCount - when limit is below 0 - return Int of 0`() {
         // Given
-        val configDefault = 3
         mockkStatic(Bukkit::class)
-        every { Bukkit.getServer().worlds[0].name } returns "world"
-        every { config.claimLimit } returns configDefault
-        every { metadata.getPlayerInfoInteger("world", playerOne,
-            "bellclaims.claim_limit", configDefault) } returns -2
+        every { config.claimLimit } returns -2
 
         // When
         val result = playerLimitService.getTotalClaimCount(playerOne)
@@ -100,30 +95,21 @@ class PlayerLimitServiceImplTest {
     @Test
     fun `getTotalClaimCount - when limit is valid - return Int`() {
         // Given
-        val configDefault = 3
-        val set = 5
         mockkStatic(Bukkit::class)
-        every { Bukkit.getServer().worlds[0].name } returns "world"
-        every { config.claimLimit } returns configDefault
-        every { metadata.getPlayerInfoInteger("world", playerOne,
-            "bellclaims.claim_limit", configDefault) } returns set
+        every { config.claimLimit } returns 5
 
         // When
         val result = playerLimitService.getTotalClaimCount(playerOne)
 
         // Then
-        Assertions.assertEquals(set, result)
+        Assertions.assertEquals(5, result)
     }
 
     @Test
     fun `getTotalClaimBlockCount - when limit is below 0 - return Int of 0`() {
         // Given
-        val configDefault = 3000
         mockkStatic(Bukkit::class)
-        every { Bukkit.getServer().worlds[0].name } returns "world"
-        every { config.claimBlockLimit } returns configDefault
-        every { metadata.getPlayerInfoInteger("world", playerOne,
-            "bellclaims.claim_block_limit", configDefault) } returns -2000
+        every { config.claimBlockLimit } returns -2000
 
         // When
         val result = playerLimitService.getTotalClaimBlockCount(playerOne)
@@ -135,19 +121,14 @@ class PlayerLimitServiceImplTest {
     @Test
     fun `getTotalClaimBlockCount - when limit is valid - return Int`() {
         // Given
-        val configDefault = 3000
-        val set = 5000
         mockkStatic(Bukkit::class)
-        every { Bukkit.getServer().worlds[0].name } returns "world"
-        every { config.claimBlockLimit } returns configDefault
-        every { metadata.getPlayerInfoInteger("world", playerOne,
-            "bellclaims.claim_block_limit", configDefault) } returns set
+        every { config.claimBlockLimit } returns 5000
 
         // When
         val result = playerLimitService.getTotalClaimBlockCount(playerOne)
 
         // Then
-        Assertions.assertEquals(set, result)
+        Assertions.assertEquals(5000, result)
     }
 
     @Test
@@ -203,14 +184,9 @@ class PlayerLimitServiceImplTest {
     @Test
     fun `getRemainingClaimCount - return Int`() {
         // Given
-        val configDefault = 3
-        val set = 5
         mockkStatic(Bukkit::class)
-        every { Bukkit.getServer().worlds[0].name } returns "world"
-        every { config.claimLimit } returns configDefault
+        every { config.claimLimit } returns 5
         every { claimRepo.getByPlayer(playerOne) } returns setOf(claimOne, claimTwo)
-        every { metadata.getPlayerInfoInteger("world", playerOne,
-            "bellclaims.claim_limit", configDefault) } returns set
 
         // When
         val result = playerLimitService.getRemainingClaimCount(playerOne)
@@ -222,16 +198,11 @@ class PlayerLimitServiceImplTest {
     @Test
     fun `getRemainingClaimBlockCount - return Int`() {
         // Given
-        val configDefault = 3000
-        val set = 5000
         mockkStatic(Bukkit::class)
-        every { Bukkit.getServer().worlds[0].name } returns "world"
-        every { config.claimBlockLimit } returns configDefault
+        every { config.claimBlockLimit } returns 5000
         every { claimRepo.getByPlayer(playerOne) } returns setOf(claimOne, claimTwo)
         every { partitionRepo.getByClaim(claimOne) } returns partitionCollectionOne.toSet()
         every { partitionRepo.getByClaim(claimTwo) } returns partitionCollectionTwo.toSet()
-        every { metadata.getPlayerInfoInteger("world", playerOne,
-            "bellclaims.claim_block_limit", configDefault) } returns set
 
         // When
         val result = playerLimitService.getRemainingClaimBlockCount(playerOne)

--- a/src/test/kotlin/dev/mizarc/bellclaims/infrastructure/services/playerlimit/VaultPlayerLimitServiceImplTest.kt
+++ b/src/test/kotlin/dev/mizarc/bellclaims/infrastructure/services/playerlimit/VaultPlayerLimitServiceImplTest.kt
@@ -1,0 +1,241 @@
+package dev.mizarc.bellclaims.infrastructure.services.playerlimit
+
+import dev.mizarc.bellclaims.api.PlayerLimitService
+import dev.mizarc.bellclaims.domain.claims.Claim
+import dev.mizarc.bellclaims.domain.claims.ClaimRepository
+import dev.mizarc.bellclaims.domain.partitions.*
+import dev.mizarc.bellclaims.domain.players.PlayerStateRepository
+import dev.mizarc.bellclaims.infrastructure.persistence.Config
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import net.milkbowl.vault.chat.Chat
+import org.bukkit.Bukkit
+import org.bukkit.OfflinePlayer
+import org.bukkit.World
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class VaultPlayerLimitServiceImplTest {
+    private lateinit var config: Config
+    private lateinit var metadata: Chat
+    private lateinit var playerStateRepo: PlayerStateRepository
+    private lateinit var claimRepo: ClaimRepository
+    private lateinit var partitionRepo: PartitionRepository
+    private lateinit var playerLimitService: PlayerLimitService
+
+    private lateinit var playerOne: OfflinePlayer
+    private lateinit var playerTwo: OfflinePlayer
+    private lateinit var playerThree: OfflinePlayer
+
+    private lateinit var uuidOne: UUID
+    private lateinit var uuidTwo: UUID
+    private lateinit var uuidThree: UUID
+
+    private lateinit var world: World
+
+    private lateinit var claimOne: Claim
+    private lateinit var partitionCollectionOne: List<Partition>
+
+    private lateinit var claimTwo: Claim
+    private lateinit var partitionCollectionTwo: List<Partition>
+
+    @BeforeEach
+    fun setup() {
+        config = mockk()
+        metadata = mockk()
+        playerStateRepo = mockk()
+        claimRepo = mockk()
+        partitionRepo = mockk()
+        playerLimitService = VaultPlayerLimitServiceImpl(config, metadata, claimRepo, partitionRepo)
+
+        playerOne = mockk<OfflinePlayer>()
+        uuidOne = UUID.fromString("22d7b7e7-7773-4f78-8e0b-817960fba37a")
+        every { playerOne.uniqueId } returns uuidOne
+
+        playerTwo = mockk<OfflinePlayer>()
+        uuidTwo = UUID.fromString("edd513e2-7dd1-4f40-9fcd-4911c198b204")
+        every { playerTwo.uniqueId } returns uuidTwo
+
+        playerThree = mockk<OfflinePlayer>()
+        uuidThree = UUID.fromString("6211420c-fa72-481a-a237-2e9f8eb8abe0")
+        every { playerThree.uniqueId } returns uuidThree
+
+        world = mockk()
+        every { world.uid } returns UUID.fromString("9e105325-aa3d-4272-8712-350b2b9f5fcc")
+
+        claimOne = Claim(world.uid, playerOne, Position3D(15,85,10), "ClaimOne")
+        partitionCollectionOne = listOf(
+            Partition(UUID.randomUUID(), claimOne.id, Area(Position2D(17, 29), Position2D(23, 39))),
+            Partition(UUID.randomUUID(), claimOne.id, Area(Position2D(11, 37), Position2D(16, 43)))
+        )
+
+        claimTwo = Claim(world.uid, playerOne, Position3D(21,74,30), "ClaimTwo")
+        partitionCollectionTwo = listOf(
+            Partition(UUID.randomUUID(), claimTwo.id, Area(Position2D(17, 29), Position2D(23, 39))),
+            Partition(UUID.randomUUID(), claimTwo.id, Area(Position2D(11, 37), Position2D(16, 43)))
+        )
+    }
+
+    @Test
+    fun `getTotalClaimCount - when limit is below 0 - return Int of 0`() {
+        // Given
+        val configDefault = 3
+        mockkStatic(Bukkit::class)
+        every { Bukkit.getServer().worlds[0].name } returns "world"
+        every { config.claimLimit } returns configDefault
+        every { metadata.getPlayerInfoInteger("world", playerOne,
+            "bellclaims.claim_limit", configDefault) } returns -2
+
+        // When
+        val result = playerLimitService.getTotalClaimCount(playerOne)
+
+        // Then
+        Assertions.assertEquals(0, result)
+    }
+
+    @Test
+    fun `getTotalClaimCount - when limit is valid - return Int`() {
+        // Given
+        val configDefault = 3
+        val set = 5
+        mockkStatic(Bukkit::class)
+        every { Bukkit.getServer().worlds[0].name } returns "world"
+        every { config.claimLimit } returns configDefault
+        every { metadata.getPlayerInfoInteger("world", playerOne,
+            "bellclaims.claim_limit", configDefault) } returns set
+
+        // When
+        val result = playerLimitService.getTotalClaimCount(playerOne)
+
+        // Then
+        Assertions.assertEquals(set, result)
+    }
+
+    @Test
+    fun `getTotalClaimBlockCount - when limit is below 0 - return Int of 0`() {
+        // Given
+        val configDefault = 3000
+        mockkStatic(Bukkit::class)
+        every { Bukkit.getServer().worlds[0].name } returns "world"
+        every { config.claimBlockLimit } returns configDefault
+        every { metadata.getPlayerInfoInteger("world", playerOne,
+            "bellclaims.claim_block_limit", configDefault) } returns -2000
+
+        // When
+        val result = playerLimitService.getTotalClaimBlockCount(playerOne)
+
+        // Then
+        Assertions.assertEquals(0, result)
+    }
+
+    @Test
+    fun `getTotalClaimBlockCount - when limit is valid - return Int`() {
+        // Given
+        val configDefault = 3000
+        val set = 5000
+        mockkStatic(Bukkit::class)
+        every { Bukkit.getServer().worlds[0].name } returns "world"
+        every { config.claimBlockLimit } returns configDefault
+        every { metadata.getPlayerInfoInteger("world", playerOne,
+            "bellclaims.claim_block_limit", configDefault) } returns set
+
+        // When
+        val result = playerLimitService.getTotalClaimBlockCount(playerOne)
+
+        // Then
+        Assertions.assertEquals(set, result)
+    }
+
+    @Test
+    fun `getUsedClaimsCount - when player has no claims - return Int of 0`() {
+        // Given
+        every { claimRepo.getByPlayer(playerOne) } returns setOf()
+
+        // When
+        val result = playerLimitService.getUsedClaimsCount(playerOne)
+
+        // Then
+        Assertions.assertEquals(0, result)
+    }
+
+    @Test
+    fun `getUsedClaimsCount - when player has claims - return Int of amount`() {
+        // Given
+        every { claimRepo.getByPlayer(playerOne) } returns setOf(claimOne, claimTwo)
+
+        // When
+        val result = playerLimitService.getUsedClaimsCount(playerOne)
+
+        // Then
+        Assertions.assertEquals(2, result)
+    }
+
+    @Test
+    fun `getUsedClaimBlockCount - when player has no claims - return Int of 0`() {
+        // Given
+        every { claimRepo.getByPlayer(playerOne) } returns setOf()
+
+        // When
+        val result = playerLimitService.getUsedClaimBlockCount(playerOne)
+
+        // Then
+        Assertions.assertEquals(0, result)
+    }
+
+    @Test
+    fun `getUsedClaimBlockCount - when player has claims with partitions - return Int of amount`() {
+        // Given
+        every { claimRepo.getByPlayer(playerOne) } returns setOf(claimOne, claimTwo)
+        every { partitionRepo.getByClaim(claimOne) } returns partitionCollectionOne.toSet()
+        every { partitionRepo.getByClaim(claimTwo) } returns partitionCollectionTwo.toSet()
+
+        // When
+        val result = playerLimitService.getUsedClaimBlockCount(playerOne)
+
+        // Then
+        Assertions.assertEquals(238, result)
+    }
+
+    @Test
+    fun `getRemainingClaimCount - return Int`() {
+        // Given
+        val configDefault = 3
+        val set = 5
+        mockkStatic(Bukkit::class)
+        every { Bukkit.getServer().worlds[0].name } returns "world"
+        every { config.claimLimit } returns configDefault
+        every { claimRepo.getByPlayer(playerOne) } returns setOf(claimOne, claimTwo)
+        every { metadata.getPlayerInfoInteger("world", playerOne,
+            "bellclaims.claim_limit", configDefault) } returns set
+
+        // When
+        val result = playerLimitService.getRemainingClaimCount(playerOne)
+
+        // Then
+        Assertions.assertEquals(3, result)
+    }
+
+    @Test
+    fun `getRemainingClaimBlockCount - return Int`() {
+        // Given
+        val configDefault = 3000
+        val set = 5000
+        mockkStatic(Bukkit::class)
+        every { Bukkit.getServer().worlds[0].name } returns "world"
+        every { config.claimBlockLimit } returns configDefault
+        every { claimRepo.getByPlayer(playerOne) } returns setOf(claimOne, claimTwo)
+        every { partitionRepo.getByClaim(claimOne) } returns partitionCollectionOne.toSet()
+        every { partitionRepo.getByClaim(claimTwo) } returns partitionCollectionTwo.toSet()
+        every { metadata.getPlayerInfoInteger("world", playerOne,
+            "bellclaims.claim_block_limit", configDefault) } returns set
+
+        // When
+        val result = playerLimitService.getRemainingClaimBlockCount(playerOne)
+
+        // Then
+        Assertions.assertEquals(4762, result)
+    }
+}


### PR DESCRIPTION
Having Vault and a registered chat API provider could stop certain server owners from wanting to use this plugin. While it is still recommended to have it installed alongside in order to gain full functionality over claim limits, it should only be an optional requirement.