### PR TITLE
Fix build for Java 21 / Minecraft 1.21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,11 +46,6 @@ java {
     toolchain.languageVersion.set(JavaLanguageVersion.of(21))
 }
 
-tasks.shadowJar {
-    relocate("co.aikar.commands", "dev.mizarc.bellclaims.acf")
-    relocate("co.aikar.locales", "dev.mizarc.bellclaims.locales")
-}
-
 tasks.test {
     useJUnitPlatform()
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
     implementation("com.zaxxer:HikariCP:5.1.0")
     implementation("co.aikar:acf-paper:0.5.1-SNAPSHOT")
     implementation("co.aikar:idb-core:1.0.0-SNAPSHOT")
-    implementation("com.github.stefvanschie.inventoryframework:IF:0.10.14")
+    implementation("com.github.stefvanschie.inventoryframework:IF:0.10.15")
     compileOnly("com.github.MilkBowl:VaultAPI:1.7")
 }
 


### PR DESCRIPTION
Removes the relocation in the `shadowJar` step and updates IF to version 0.10.15