### PR TITLE
Recategorise all passive mob permissions into one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ## [Latest]
 Update to support MC version 1.21
 
+### Changed
+- Mob hurt/leash/shear claim permissions merged into one "Husbandry" permission.
+
 ## [0.1.2]
 Update to support MC Version 1.20.6
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
@@ -21,8 +21,7 @@ enum class ClaimPermission(val parent: ClaimPermission?, val events: Array<Permi
         PermissionBehaviour.itemFramePlace,
         PermissionBehaviour.hangingEntityBreak,
         PermissionBehaviour.fertilize,
-        PermissionBehaviour.farmlandStep,
-        PermissionBehaviour.breedEntity,
+        PermissionBehaviour.farmlandStep
     )),
 
     /**
@@ -79,23 +78,16 @@ enum class ClaimPermission(val parent: ClaimPermission?, val events: Array<Permi
     VillagerTrade(null, arrayOf(PermissionBehaviour.villagerTrade)),
 
     /**
-     * When an entity is hurt by a player.
+     * When a passive mob is interacted with.
      */
-    MobHurt(null, arrayOf(PermissionBehaviour.playerDamageEntity)),
-
-    /**
-     * When an entity is leashed by a player.
-     */
-    MobLeash(null, arrayOf(
+    Husbandry(null, arrayOf(
+        PermissionBehaviour.playerDamageEntity,
         PermissionBehaviour.leashEntity,
         PermissionBehaviour.fishingRod,
-        PermissionBehaviour.takeLeadFromFence
-    )),
-
-    /**
-     * When an entity is sheared by a player.
-     */
-    MobShear(null, arrayOf(PermissionBehaviour.shearEntity));
+        PermissionBehaviour.takeLeadFromFence,
+        PermissionBehaviour.shearEntity,
+        PermissionBehaviour.breedEntity,
+    ));
 
     companion object {
         /**

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
@@ -74,11 +74,9 @@ enum class ClaimPermission(val parent: ClaimPermission?, val events: Array<Permi
      */
     Husbandry(null, arrayOf(
         PermissionBehaviour.playerDamageEntity,
-        PermissionBehaviour.leashEntity,
+        PermissionBehaviour.interactAnimals,
         PermissionBehaviour.fishingRod,
         PermissionBehaviour.takeLeadFromFence,
-        PermissionBehaviour.shearEntity,
-        PermissionBehaviour.interactAnimals,
     ));
 
     companion object {

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
@@ -78,7 +78,7 @@ enum class ClaimPermission(val parent: ClaimPermission?, val events: Array<Permi
         PermissionBehaviour.fishingRod,
         PermissionBehaviour.takeLeadFromFence,
         PermissionBehaviour.shearEntity,
-        PermissionBehaviour.breedEntity,
+        PermissionBehaviour.interactAnimals,
     ));
 
     companion object {

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
@@ -25,11 +25,9 @@ enum class ClaimPermission(val parent: ClaimPermission?, val events: Array<Permi
     )),
 
     /**
-     * When a block is interacted with by a player.
+     * When a container is opened by a player.
      */
-    ContainerInspect(null, arrayOf(
-        PermissionBehaviour.openInventory
-    )),
+    ContainerInspect(null, arrayOf(PermissionBehaviour.openInventory)),
 
     /**
      * When an item is taken or put in display blocks.
@@ -54,23 +52,17 @@ enum class ClaimPermission(val parent: ClaimPermission?, val events: Array<Permi
     /**
      * When the sign edit menu is opened.
      */
-    SignEdit(null, arrayOf(
-        PermissionBehaviour.signEditing
-    )),
+    SignEdit(null, arrayOf(PermissionBehaviour.signEditing)),
 
     /**
      * When a device used to activate redstone is interacted with by a player.
      */
-    RedstoneInteract(null, arrayOf(
-        PermissionBehaviour.redstoneInteract
-    )),
+    RedstoneInteract(null, arrayOf(PermissionBehaviour.redstoneInteract)),
 
     /**
      * When a door is opened by a player.
      */
-    DoorOpen(null, arrayOf(
-        PermissionBehaviour.openDoor
-    )),
+    DoorOpen(null, arrayOf(PermissionBehaviour.openDoor)),
 
     /**
      * When a villager or travelling merchant is traded with by a player.

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
@@ -83,6 +83,7 @@ class PermissionBehaviour {
         // Used for taking and placing armour from armour stand
         val armorStandManipulate = PermissionExecutor(PlayerArmorStandManipulateEvent::class.java, Companion::cancelEvent, Companion::getArmorStandLocation, Companion::getArmorStandManipulator)
 
+        // Used to change the contents of a flower pot
         val flowerPotManipulate = PermissionExecutor(PlayerFlowerPotManipulateEvent::class.java, Companion::cancelFlowerPotInteract, Companion::getPlayerFlowerPotManipulateLocation, Companion::getPlayerFlowerPotManipulatePlayer)
 
         // Used for putting and taking items from display blocks such as flower pots and chiseled bookshelves

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
@@ -16,6 +16,7 @@ import org.bukkit.event.Listener
 import org.bukkit.event.block.*
 import org.bukkit.event.entity.EntityBreedEvent
 import org.bukkit.event.entity.EntityDamageByEntityEvent
+import org.bukkit.event.entity.EntityInteractEvent
 import org.bukkit.event.entity.EntityPlaceEvent
 import org.bukkit.event.entity.PlayerLeashEntityEvent
 import org.bukkit.event.hanging.HangingBreakByEntityEvent
@@ -97,7 +98,7 @@ class PermissionBehaviour {
         val miscEntityDisplayInteractions = PermissionExecutor(PlayerInteractEntityEvent::class.java, Companion::cancelMiscEntityDisplayInteractions, Companion::getPlayerInteractEntityLocation, Companion::getPlayerInteractEntityPlayer)
 
         // Used for breeding passive mobs with food
-        val breedEntity = PermissionExecutor(EntityBreedEvent::class.java, Companion::cancelEvent, Companion::getEntityBreedLocation, Companion::getEntityBreedPlayer)
+        val interactAnimals = PermissionExecutor(PlayerInteractEntityEvent::class.java, Companion::cancelAnimalInteract, Companion::getAnimalInteractLocation, Companion::getAnimalInteractPlayer)
 
         // Used for taking items out of entities by damaging them such as with item frames
         val miscEntityDisplayDamage = PermissionExecutor(EntityDamageByEntityEvent::class.java, Companion::cancelStaticEntityDamage, Companion::getEntityDamageByEntityLocation, Companion::getEntityDamageSourcePlayer)
@@ -207,15 +208,21 @@ class PermissionBehaviour {
             return event.player
         }
 
-        private fun getEntityBreedLocation(event: Event): Location? {
-            if (event !is EntityBreedEvent) return null
-            return event.mother.location
+        private fun cancelAnimalInteract(listener: Listener, event: Event): Boolean {
+            if (event !is PlayerInteractEntityEvent) return false
+            if (event.rightClicked !is Animals) return false
+            event.isCancelled = true
+            return true
         }
 
-        private fun getEntityBreedPlayer(event: Event): Player? {
-            if (event !is EntityBreedEvent) return null
-            if (event.breeder !is Player) return null
-            return event.breeder as Player;
+        private fun getAnimalInteractLocation(event: Event): Location? {
+            if (event !is PlayerInteractEntityEvent) return null
+            return event.rightClicked.location
+        }
+
+        private fun getAnimalInteractPlayer(event: Event): Player? {
+            if (event !is PlayerInteractEntityEvent) return null
+            return event.player
         }
 
         private fun getPlayerInteractEntityLocation(event: Event): Location? {

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
@@ -77,12 +77,6 @@ class PermissionBehaviour {
         // Used for damaging passive mobs
         val playerDamageEntity = PermissionExecutor(EntityDamageByEntityEvent::class.java, Companion::cancelEntityDamageEvent, Companion::getEntityDamageByEntityLocation, Companion::getEntityDamageSourcePlayer)
 
-        // Used for leashing passive mobs with lead
-        val leashEntity = PermissionExecutor(PlayerLeashEntityEvent::class.java, Companion::cancelEvent, Companion::getLeashEntityLocation, Companion::getLeashPlayer)
-
-        // Used for shearing mobs with a shear
-        val shearEntity = PermissionExecutor(PlayerShearEntityEvent::class.java, Companion::cancelEvent, Companion::getShearEntityLocation, Companion::getShearPlayer)
-
         // Used for editing sign text
         val signEditing = PermissionExecutor(PlayerOpenSignEvent::class.java, Companion::cancelEvent, Companion::getPlayerOpenSignLocation, Companion::getPlayerOpenSignPlayer)
 
@@ -538,38 +532,6 @@ class PermissionBehaviour {
         private fun getInventoryInteractPlayer(e: Event): Player? {
             if (e !is InventoryOpenEvent) return null
             return e.player as Player
-        }
-
-        /**
-         * Get the location of an entity that is being leashed by a player.
-         */
-        private fun getLeashEntityLocation(e: Event): Location? {
-            if (e !is PlayerLeashEntityEvent) return null
-            return e.entity.location
-        }
-
-        /**
-         * Get the player that is leashing an entity.
-         */
-        private fun getLeashPlayer(e: Event): Player? {
-            if (e !is PlayerLeashEntityEvent) return null
-            return e.player
-        }
-
-        /**
-         * Get the location of an entity that is being sheared by a player.
-         */
-        private fun getShearEntityLocation(e: Event): Location? {
-            if (e !is PlayerShearEntityEvent) return null
-            return e.entity.location
-        }
-
-        /**
-         * Get the player that is shearing an entity.
-         */
-        private fun getShearPlayer(e: Event): Player? {
-            if (e !is PlayerShearEntityEvent) return null
-            return e.player
         }
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/utils/PermissionDisplay.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/utils/PermissionDisplay.kt
@@ -19,9 +19,7 @@ fun ClaimPermission.getIcon(): ItemStack {
         ClaimPermission.RedstoneInteract -> ItemStack(Material.LEVER)
         ClaimPermission.DoorOpen -> ItemStack(Material.ACACIA_DOOR)
         ClaimPermission.VillagerTrade -> ItemStack(Material.EMERALD)
-        ClaimPermission.MobHurt -> ItemStack(Material.IRON_SWORD)
-        ClaimPermission.MobLeash -> ItemStack(Material.LEAD)
-        ClaimPermission.MobShear -> ItemStack(Material.SHEARS)
+        ClaimPermission.Husbandry -> ItemStack(Material.LEAD)
     }
 }
 
@@ -40,9 +38,7 @@ fun ClaimPermission.getDisplayName(): String {
         ClaimPermission.RedstoneInteract -> "Redstone Interact"
         ClaimPermission.DoorOpen -> "Door Open"
         ClaimPermission.VillagerTrade -> "Villager Trade"
-        ClaimPermission.MobHurt -> "Mob Hurt"
-        ClaimPermission.MobLeash -> "Mob Leash"
-        ClaimPermission.MobShear -> "Mob Shear"
+        ClaimPermission.Husbandry -> "Husbandry"
     }
 }
 
@@ -61,8 +57,6 @@ fun ClaimPermission.getDescription(): String {
         ClaimPermission.RedstoneInteract -> "Grants permission to use redstone interactions (Buttons, Levers, Pressure Plates)"
         ClaimPermission.DoorOpen -> "Grants permission to open and close doors"
         ClaimPermission.VillagerTrade -> "Grants permission to trade with villagers"
-        ClaimPermission.MobHurt -> "Grants permission to damage passive mobs"
-        ClaimPermission.MobLeash -> "Grants permission to use leads on passive mobs"
-        ClaimPermission.MobShear -> "Grants permission to use shears on passive mobs"
+        ClaimPermission.Husbandry -> "Grants permission to interact with passive animals"
     }
 }

--- a/src/test/kotlin/dev/mizarc/bellclaims/infrastructure/services/PlayerPermissionServiceImplTest.kt
+++ b/src/test/kotlin/dev/mizarc/bellclaims/infrastructure/services/PlayerPermissionServiceImplTest.kt
@@ -46,13 +46,11 @@ class PlayerPermissionServiceImplTest {
     @Test
     fun `doesPlayerHavePermission - when player doesn't have permission - returns False`() {
         // Given
-        val playerOnePermissions = setOf(ClaimPermission.MobHurt, ClaimPermission.Build)
-        val playerTwoPermissions = setOf(ClaimPermission.ContainerInspect,
-            ClaimPermission.SignEdit, ClaimPermission.RedstoneInteract)
+        val playerOnePermissions = setOf(ClaimPermission.Husbandry, ClaimPermission.Build)
         every { permissionRepo.getByPlayer(claim, playerOne) } returns playerOnePermissions
 
         // When
-        val result = playerPermissionService.doesPlayerHavePermission(claim, playerOne, ClaimPermission.MobLeash)
+        val result = playerPermissionService.doesPlayerHavePermission(claim, playerOne, ClaimPermission.VehicleDeploy)
 
         // Then
         assertFalse(result)
@@ -61,7 +59,7 @@ class PlayerPermissionServiceImplTest {
     @Test
     fun `doesPlayerHavePermission - when player does have permission - returns True`() {
         // Given
-        val playerOnePermissions = setOf(ClaimPermission.MobHurt, ClaimPermission.Build)
+        val playerOnePermissions = setOf(ClaimPermission.Husbandry, ClaimPermission.Build)
         val playerTwoPermissions = setOf(ClaimPermission.ContainerInspect,
             ClaimPermission.SignEdit, ClaimPermission.RedstoneInteract)
         every { permissionRepo.getByPlayer(claim, playerOne) } returns playerOnePermissions
@@ -76,7 +74,7 @@ class PlayerPermissionServiceImplTest {
     @Test
     fun `getByClaim - returns expected Permission Map`() {
         // Given
-        val playerOnePermissions = setOf(ClaimPermission.MobHurt, ClaimPermission.Build)
+        val playerOnePermissions = setOf(ClaimPermission.SignEdit, ClaimPermission.Build)
         val playerTwoPermissions = setOf(ClaimPermission.ContainerInspect,
             ClaimPermission.SignEdit, ClaimPermission.RedstoneInteract)
         val permissions = mapOf(uuidOne to playerOnePermissions, uuidTwo to playerTwoPermissions)
@@ -95,7 +93,7 @@ class PlayerPermissionServiceImplTest {
     @Test
     fun `getByPlayer - returns expected Permission Set`() {
         // Given
-        val permissions = setOf(ClaimPermission.MobHurt, ClaimPermission.Build)
+        val permissions = setOf(ClaimPermission.SignEdit, ClaimPermission.Build)
         every { permissionRepo.getByPlayer(claim, playerOne) } returns permissions
 
         // When
@@ -127,7 +125,7 @@ class PlayerPermissionServiceImplTest {
         every { permissionRepo.add(claim, playerOne, any()) } just runs
 
         // When
-        val result = playerPermissionService.addForPlayer(claim, playerOne, ClaimPermission.MobLeash)
+        val result = playerPermissionService.addForPlayer(claim, playerOne, ClaimPermission.Husbandry)
 
         // Then
         assertEquals(PlayerPermissionChangeResult.SUCCESS, result)


### PR DESCRIPTION
Players generally found no use for the separation of mob permissions. It may be a better idea to just merge them all into one "Husbandry" permission that allows players to do anything pertaining to the maintenance of farm animals.