### PR TITLE
Fixed ability to break blocks to the north and south of bell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Update to support MC version 1.21
 ### Changed
 - Mob hurt/leash/shear claim permissions merged into one "Husbandry" permission.
 
+### Fixed
+- Inability to break blocks in north or south direction of bell regardless of bell attachment.
+
 ## [0.1.2]
 Update to support MC Version 1.20.6
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimDestructionListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimDestructionListener.kt
@@ -202,9 +202,9 @@ class ClaimDestructionListener(val claimService: ClaimService,
                 bell.attachment == Bell.Attachment.FLOOR && blockAt.getRelative(BlockFace.DOWN) == block ||
                 bell.attachment == Bell.Attachment.SINGLE_WALL &&
                 (bell.facing == BlockFace.EAST && blockAt.getRelative(BlockFace.EAST) == block ||
-                        bell.facing == BlockFace.WEST && blockAt.getRelative(BlockFace.WEST) == block) ||
-                bell.facing == BlockFace.NORTH && blockAt.getRelative(BlockFace.NORTH) == block ||
-                bell.facing == BlockFace.SOUTH && blockAt.getRelative(BlockFace.SOUTH) == block) {
+                        bell.facing == BlockFace.WEST && blockAt.getRelative(BlockFace.WEST) == block ||
+                        bell.facing == BlockFace.NORTH && blockAt.getRelative(BlockFace.NORTH) == block ||
+                        bell.facing == BlockFace.SOUTH && blockAt.getRelative(BlockFace.SOUTH) == block)) {
                 return true
             }
         }


### PR DESCRIPTION
The bell attachment checks were done incorrectly so it would always check the north and south directions regardless of if the bell was attached to a block in that direction.