### PR TITLE
Add protection for dragon egg being teleported from player right clicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ## [Latest]
 Update to support MC version 1.21
 
+### Added
+- Protection against players right-clicking dragon eggs, causing it to teleport.
+
 ### Changed
 - Mob hurt/leash/shear claim permissions merged into one "Husbandry" permission.
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
@@ -21,7 +21,8 @@ enum class ClaimPermission(val parent: ClaimPermission?, val events: Array<Permi
         PermissionBehaviour.itemFramePlace,
         PermissionBehaviour.hangingEntityBreak,
         PermissionBehaviour.fertilize,
-        PermissionBehaviour.farmlandStep
+        PermissionBehaviour.farmlandStep,
+        PermissionBehaviour.dragonEggTeleport
     )),
 
     /**

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
@@ -4,6 +4,7 @@ import io.papermc.paper.event.player.PlayerFlowerPotManipulateEvent
 import io.papermc.paper.event.player.PlayerOpenSignEvent
 import org.bukkit.Location
 import org.bukkit.Material
+import org.bukkit.block.BlockType
 import org.bukkit.block.data.AnaloguePowerable
 import org.bukkit.block.data.Openable
 import org.bukkit.block.data.Powerable
@@ -118,6 +119,9 @@ class PermissionBehaviour {
 
         // Used for placing vehicles
         val vehiclePlace = PermissionExecutor(EntityPlaceEvent::class.java, Companion::cancelVehiclePlace, Companion::getEntityPlaceLocation, Companion::getEntityPlacePlayer)
+
+        // Used for dragon egg teleports
+        val dragonEggTeleport = PermissionExecutor(PlayerInteractEvent::class.java, Companion::cancelDragonEggTeleport, Companion::getInteractEventLocation, Companion::getInteractEventPlayer)
 
         /**
          * Cancel any cancellable event.
@@ -273,6 +277,14 @@ class PermissionBehaviour {
             if (event.action != Action.RIGHT_CLICK_BLOCK) return false
             val item = event.item ?: return false
             if (item.type != Material.ITEM_FRAME) return false
+            event.isCancelled = true
+            return true
+        }
+
+        private fun cancelDragonEggTeleport(listener: Listener, event: Event): Boolean {
+            if (event !is PlayerInteractEvent) return false
+            val block = event.clickedBlock ?: return false
+            if (block.type != Material.DRAGON_EGG) return false
             event.isCancelled = true
             return true
         }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
@@ -529,14 +529,6 @@ class PermissionBehaviour {
         }
 
         /**
-         * Get the player that is damaging a block.
-         */
-        private fun getBlockDamager(e: Event): Player? {
-            if (e !is BlockDamageEvent) return null
-            return e.player
-        }
-
-        /**
          * Get the location of an entity being damaged by another entity.
          */
         private fun getEntityDamageByEntityLocation(e: Event): Location? {

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
@@ -148,27 +148,6 @@ class PermissionBehaviour {
             return true
         }
 
-        private fun getVehicleDestroyPlayer(event: Event): Player? {
-            if (event !is VehicleDestroyEvent) return null
-            if (event.attacker !is Player) return null
-            return event.attacker as Player
-        }
-
-        private fun getVehicleDestroyLocation(event: Event): Location? {
-            if (event !is VehicleDestroyEvent) return null
-            return event.vehicle.location
-        }
-
-        private fun getPlayerOpenSignPlayer(event: Event): Player? {
-            if (event !is PlayerOpenSignEvent) return null
-            return event.player
-        }
-
-        private fun getPlayerOpenSignLocation(event: Event): Location? {
-            if (event !is PlayerOpenSignEvent) return null
-            return event.sign.location
-        }
-
         private fun cancelFarmlandStep(listener: Listener, event: Event): Boolean {
             if (event !is PlayerInteractEvent) return false
             if (event.action != Action.PHYSICAL) return false
@@ -185,14 +164,11 @@ class PermissionBehaviour {
             return true
         }
 
-        private fun getHangingBreakByEntityEventPlayer(event: Event): Player? {
-            if (event !is HangingBreakByEntityEvent) return null
-            return event.remover as? Player ?: return null
-        }
-
-        private fun getHangingBreakByEntityEventLocation(event: Event): Location? {
-            if (event !is HangingBreakByEntityEvent) return null
-            return event.entity.location
+        private fun cancelAnimalInteract(listener: Listener, event: Event): Boolean {
+            if (event !is PlayerInteractEntityEvent) return false
+            if (event.rightClicked !is Animals) return false
+            event.isCancelled = true
+            return true
         }
 
         private fun cancelMiscEntityDisplayInteractions(listener: Listener, event: Event): Boolean {
@@ -202,47 +178,10 @@ class PermissionBehaviour {
             return true
         }
 
-        private fun getPlayerInteractEntityPlayer(event: Event): Player? {
-            if (event !is PlayerInteractEntityEvent) return null
-            return event.player
-        }
-
-        private fun cancelAnimalInteract(listener: Listener, event: Event): Boolean {
-            if (event !is PlayerInteractEntityEvent) return false
-            if (event.rightClicked !is Animals) return false
-            event.isCancelled = true
-            return true
-        }
-
-        private fun getAnimalInteractLocation(event: Event): Location? {
-            if (event !is PlayerInteractEntityEvent) return null
-            return event.rightClicked.location
-        }
-
-        private fun getAnimalInteractPlayer(event: Event): Player? {
-            if (event !is PlayerInteractEntityEvent) return null
-            return event.player
-        }
-
-        private fun getPlayerInteractEntityLocation(event: Event): Location? {
-            if (event !is PlayerInteractEntityEvent) return null
-            return event.rightClicked.location
-        }
-
         private fun cancelFlowerPotInteract(listener: Listener, event: Event): Boolean {
             if (event !is PlayerFlowerPotManipulateEvent) return false
             event.isCancelled = true
             return true
-        }
-
-        private fun getPlayerFlowerPotManipulatePlayer(event: Event): Player? {
-            if (event !is PlayerFlowerPotManipulateEvent) return null
-            return event.player
-        }
-
-        private fun getPlayerFlowerPotManipulateLocation(event: Event): Location? {
-            if (event !is PlayerFlowerPotManipulateEvent) return null
-            return event.flowerpot.location
         }
 
         /**
@@ -289,23 +228,6 @@ class PermissionBehaviour {
             return true
         }
 
-        /**
-         * Get the location of an entity being placed.
-         */
-        private fun getInteractEventLocation(event: Event): Location? {
-            if (event !is PlayerInteractEvent) return null
-            val block = event.clickedBlock ?: return null
-            return block.location
-        }
-
-        /**
-         * Get the player that placed the entity.
-         */
-        private fun getInteractEventPlayer(event: Event): Player? {
-            if (event !is PlayerInteractEvent) return null
-            return event.player
-        }
-
         private fun cancelSpecialEntityEvent(listener: Listener, event: Event): Boolean {
             if (event !is EntityDamageByEntityEvent) return false
             if (event.entity is ArmorStand) {
@@ -316,56 +238,12 @@ class PermissionBehaviour {
             return false
         }
 
-        /**
-         * Get the location of an entity being placed.
-         */
-        private fun getPlayerDamageSpecialLocation(event: Event): Location? {
-            if (event !is EntityDamageByEntityEvent) return null
-            return event.entity.location
-        }
-
-        /**
-         * Get the player that placed the entity.
-         */
-        private fun getPlayerDamageSpecialPlayer(event: Event): Player? {
-            if (event !is EntityDamageByEntityEvent) return null
-            if (event.damager !is Player) return null
-            return event.damager as Player
-        }
-
-        /**
-         * Get the location of an entity being placed.
-         */
-        private fun getEntityPlaceLocation(event: Event): Location? {
-            if (event !is EntityPlaceEvent) return null
-            return event.entity.location
-        }
-
-        /**
-         * Get the player that placed the entity.
-         */
-        private fun getEntityPlacePlayer(event: Event): Player? {
-            if (event !is EntityPlaceEvent) return null
-            return event.player
-        }
-
         private fun cancelFishingEvent(listener: Listener, event: Event): Boolean {
             if (event !is PlayerFishEvent) return false
             val caught = event.caught ?: return false
             if (caught is Monster && caught is Player) return false
             event.isCancelled = true
             return true
-        }
-
-        private fun getFishingLocation(event: Event): Location? {
-            if (event !is PlayerFishEvent) return null
-            val caught = event.caught ?: return null
-            return caught.location
-        }
-
-        private fun getFishingPlayer(event: Event): Player? {
-            if (event !is PlayerFishEvent) return null
-            return event.player
         }
 
         /**
@@ -440,6 +318,128 @@ class PermissionBehaviour {
             if (t != InventoryType.MERCHANT) return false
             event.isCancelled = true
             return true
+        }
+
+        private fun getVehicleDestroyPlayer(event: Event): Player? {
+            if (event !is VehicleDestroyEvent) return null
+            if (event.attacker !is Player) return null
+            return event.attacker as Player
+        }
+
+        private fun getVehicleDestroyLocation(event: Event): Location? {
+            if (event !is VehicleDestroyEvent) return null
+            return event.vehicle.location
+        }
+
+        private fun getPlayerOpenSignPlayer(event: Event): Player? {
+            if (event !is PlayerOpenSignEvent) return null
+            return event.player
+        }
+
+        private fun getPlayerOpenSignLocation(event: Event): Location? {
+            if (event !is PlayerOpenSignEvent) return null
+            return event.sign.location
+        }
+
+        private fun getHangingBreakByEntityEventPlayer(event: Event): Player? {
+            if (event !is HangingBreakByEntityEvent) return null
+            return event.remover as? Player ?: return null
+        }
+
+        private fun getHangingBreakByEntityEventLocation(event: Event): Location? {
+            if (event !is HangingBreakByEntityEvent) return null
+            return event.entity.location
+        }
+
+        private fun getPlayerInteractEntityPlayer(event: Event): Player? {
+            if (event !is PlayerInteractEntityEvent) return null
+            return event.player
+        }
+
+        private fun getAnimalInteractLocation(event: Event): Location? {
+            if (event !is PlayerInteractEntityEvent) return null
+            return event.rightClicked.location
+        }
+
+        private fun getAnimalInteractPlayer(event: Event): Player? {
+            if (event !is PlayerInteractEntityEvent) return null
+            return event.player
+        }
+
+        private fun getPlayerInteractEntityLocation(event: Event): Location? {
+            if (event !is PlayerInteractEntityEvent) return null
+            return event.rightClicked.location
+        }
+
+        private fun getPlayerFlowerPotManipulatePlayer(event: Event): Player? {
+            if (event !is PlayerFlowerPotManipulateEvent) return null
+            return event.player
+        }
+
+        private fun getPlayerFlowerPotManipulateLocation(event: Event): Location? {
+            if (event !is PlayerFlowerPotManipulateEvent) return null
+            return event.flowerpot.location
+        }
+
+        /**
+         * Get the location of an entity being placed.
+         */
+        private fun getInteractEventLocation(event: Event): Location? {
+            if (event !is PlayerInteractEvent) return null
+            val block = event.clickedBlock ?: return null
+            return block.location
+        }
+
+        /**
+         * Get the player that placed the entity.
+         */
+        private fun getInteractEventPlayer(event: Event): Player? {
+            if (event !is PlayerInteractEvent) return null
+            return event.player
+        }
+
+        /**
+         * Get the location of an entity being placed.
+         */
+        private fun getPlayerDamageSpecialLocation(event: Event): Location? {
+            if (event !is EntityDamageByEntityEvent) return null
+            return event.entity.location
+        }
+
+        /**
+         * Get the player that placed the entity.
+         */
+        private fun getPlayerDamageSpecialPlayer(event: Event): Player? {
+            if (event !is EntityDamageByEntityEvent) return null
+            if (event.damager !is Player) return null
+            return event.damager as Player
+        }
+
+        /**
+         * Get the location of an entity being placed.
+         */
+        private fun getEntityPlaceLocation(event: Event): Location? {
+            if (event !is EntityPlaceEvent) return null
+            return event.entity.location
+        }
+
+        /**
+         * Get the player that placed the entity.
+         */
+        private fun getEntityPlacePlayer(event: Event): Player? {
+            if (event !is EntityPlaceEvent) return null
+            return event.player
+        }
+
+        private fun getFishingLocation(event: Event): Location? {
+            if (event !is PlayerFishEvent) return null
+            val caught = event.caught ?: return null
+            return caught.location
+        }
+
+        private fun getFishingPlayer(event: Event): Player? {
+            if (event !is PlayerFishEvent) return null
+            return event.player
         }
 
         /**

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
@@ -4,7 +4,6 @@ import io.papermc.paper.event.player.PlayerFlowerPotManipulateEvent
 import io.papermc.paper.event.player.PlayerOpenSignEvent
 import org.bukkit.Location
 import org.bukkit.Material
-import org.bukkit.block.BlockType
 import org.bukkit.block.data.AnaloguePowerable
 import org.bukkit.block.data.Openable
 import org.bukkit.block.data.Powerable
@@ -15,11 +14,8 @@ import org.bukkit.event.Cancellable
 import org.bukkit.event.Event
 import org.bukkit.event.Listener
 import org.bukkit.event.block.*
-import org.bukkit.event.entity.EntityBreedEvent
 import org.bukkit.event.entity.EntityDamageByEntityEvent
-import org.bukkit.event.entity.EntityInteractEvent
 import org.bukkit.event.entity.EntityPlaceEvent
-import org.bukkit.event.entity.PlayerLeashEntityEvent
 import org.bukkit.event.hanging.HangingBreakByEntityEvent
 import org.bukkit.event.inventory.InventoryOpenEvent
 import org.bukkit.event.inventory.InventoryType
@@ -124,7 +120,7 @@ class PermissionBehaviour {
         val dragonEggTeleport = PermissionExecutor(PlayerInteractEvent::class.java, Companion::cancelDragonEggTeleport, Companion::getInteractEventLocation, Companion::getInteractEventPlayer)
 
         /**
-         * Cancel any cancellable event.
+         * Cancels any cancellable event.
          */
         private fun cancelEvent(listener: Listener, event: Event): Boolean {
             if (event is Cancellable) {
@@ -134,6 +130,9 @@ class PermissionBehaviour {
             return false
         }
 
+        /**
+         * Cancels the action of placing down a vehicle such as a boat or minecart.
+         */
         private fun cancelVehiclePlace(listener: Listener, event: Event): Boolean {
             if (event !is EntityPlaceEvent) return false
             if (event.entity !is Vehicle) return false
@@ -141,6 +140,9 @@ class PermissionBehaviour {
             return true
         }
 
+        /**
+         * Cancels the action of placing down other non-vehicle entities.
+         */
         private fun cancelEntityPlace(listener: Listener, event: Event): Boolean {
             if (event !is EntityPlaceEvent) return false
             if (event.entity is Vehicle) return false
@@ -148,6 +150,9 @@ class PermissionBehaviour {
             return true
         }
 
+        /**
+         * Cancels the action of breaking farmland from stepping.
+         */
         private fun cancelFarmlandStep(listener: Listener, event: Event): Boolean {
             if (event !is PlayerInteractEvent) return false
             if (event.action != Action.PHYSICAL) return false
@@ -157,6 +162,9 @@ class PermissionBehaviour {
             return true
         }
 
+        /**
+         * Cancels the action of removing a lead from a fence.
+         */
         private fun cancelLeadRemoval(listener: Listener, event: Event): Boolean {
             if (event !is PlayerInteractEntityEvent) return false
             if (event.rightClicked !is LeashHitch) return false
@@ -164,6 +172,9 @@ class PermissionBehaviour {
             return true
         }
 
+        /**
+         * Cancels the action of animal interactions such as leadingk, shearing or feeding.
+         */
         private fun cancelAnimalInteract(listener: Listener, event: Event): Boolean {
             if (event !is PlayerInteractEntityEvent) return false
             if (event.rightClicked !is Animals) return false
@@ -171,6 +182,9 @@ class PermissionBehaviour {
             return true
         }
 
+        /**
+         * Cancels all other entity display interactions such as item frames.
+         */
         private fun cancelMiscEntityDisplayInteractions(listener: Listener, event: Event): Boolean {
             if (event !is PlayerInteractEntityEvent) return false
             if (event.rightClicked.type != EntityType.ITEM_FRAME) return false
@@ -178,6 +192,9 @@ class PermissionBehaviour {
             return true
         }
 
+        /**
+         * Cancels the action of interacting with flower pots.
+         */
         private fun cancelFlowerPotInteract(listener: Listener, event: Event): Boolean {
             if (event !is PlayerFlowerPotManipulateEvent) return false
             event.isCancelled = true
@@ -185,7 +202,7 @@ class PermissionBehaviour {
         }
 
         /**
-         * Get the location of an entity being placed.
+         * Cancels the action of interacting with misc display blocks such as item frames.
          */
         private fun cancelMiscDisplayInteractions(listener: Listener, event: Event): Boolean {
             if (event !is PlayerInteractEvent) return false
@@ -199,7 +216,7 @@ class PermissionBehaviour {
         }
 
         /**
-         * Get the location of an entity being placed.
+         * Cancels the action of placing water or lava buckets.
          */
         private fun cancelFluidPlace(listener: Listener, event: Event): Boolean {
             if (event !is PlayerInteractEvent) return false
@@ -211,6 +228,9 @@ class PermissionBehaviour {
             return true
         }
 
+        /**
+         * Cancels the action of placing down item frames.
+         */
         private fun cancelItemFramePlace(listener: Listener, event: Event): Boolean {
             if (event !is PlayerInteractEvent) return false
             if (event.action != Action.RIGHT_CLICK_BLOCK) return false
@@ -220,6 +240,9 @@ class PermissionBehaviour {
             return true
         }
 
+        /**
+         * Cancels the action of interacting with a dragon egg, causing it to teleport.
+         */
         private fun cancelDragonEggTeleport(listener: Listener, event: Event): Boolean {
             if (event !is PlayerInteractEvent) return false
             val block = event.clickedBlock ?: return false
@@ -228,6 +251,9 @@ class PermissionBehaviour {
             return true
         }
 
+        /**
+         * Cancels the action of damaging an armor stand.
+         */
         private fun cancelSpecialEntityEvent(listener: Listener, event: Event): Boolean {
             if (event !is EntityDamageByEntityEvent) return false
             if (event.entity is ArmorStand) {
@@ -238,6 +264,9 @@ class PermissionBehaviour {
             return false
         }
 
+        /**
+         * Cancels the action of reeling in passive mobs with a fishing rod.
+         */
         private fun cancelFishingEvent(listener: Listener, event: Event): Boolean {
             if (event !is PlayerFishEvent) return false
             val caught = event.caught ?: return false
@@ -247,7 +276,7 @@ class PermissionBehaviour {
         }
 
         /**
-         * Cancel entity damage if caused by a player entity. Does not cancel if entity is considered a monster.
+         * Cancels the action of damaging passive mobs caused by the player.
          */
         private fun cancelEntityDamageEvent(listener: Listener, event: Event): Boolean {
             if (event !is EntityDamageByEntityEvent) return false
@@ -257,6 +286,9 @@ class PermissionBehaviour {
             return true
         }
 
+        /**
+         * Cancels the action of damaging static entities such as item frames.
+         */
         private fun cancelStaticEntityDamage(listener: Listener, event: Event): Boolean {
             if (event !is EntityDamageByEntityEvent) return false
             if (event.damager !is Player) return false
@@ -265,6 +297,9 @@ class PermissionBehaviour {
             return true
         }
 
+        /**
+         * Cancels the action of door opening.
+         */
         private fun cancelDoorOpen(listener: Listener, event: Event): Boolean {
             if (event !is PlayerInteractEvent) return false
             val block = event.clickedBlock ?: return false
@@ -273,6 +308,9 @@ class PermissionBehaviour {
             return true
         }
 
+        /**
+         * Cancels the action of redstone triggers such as buttons or levers.
+         */
         private fun cancelRedstoneInteract(listener: Listener, event: Event): Boolean {
             if (event !is PlayerInteractEvent) return false
             val block = event.clickedBlock ?: return false
@@ -288,7 +326,7 @@ class PermissionBehaviour {
         }
 
         /**
-         * Cancel inventory open events if the inventory is a chest.
+         * Cancel the action of opening inventories such as chests and furnaces.
          */
         private fun cancelOpenInventory(listener: Listener, event: Event): Boolean {
             if (event !is InventoryOpenEvent) return false
@@ -310,7 +348,7 @@ class PermissionBehaviour {
         }
 
         /**
-         * Cancel entity interactions if the player is trading with a village.
+         * Cancels the action of opening the villager trading menu.
          */
         private fun cancelVillagerOpen(listener: Listener, event: Event): Boolean {
             if (event !is InventoryOpenEvent) return false


### PR DESCRIPTION
Players that do not have any permissions in a claim are still able to right click dragon eggs from inside the claim, which causes the dragon egg to teleport. This is now part of the build permission.