### PR TITLE
Added protection against the usage of dyes and glow ink on signs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Update to support MC version 1.21
 - Protection against players right-clicking dragon eggs, causing it to teleport. Requires the build permission.
 - Protection against fluid being picked up from the ground. Requires the build permission.
 - Protection against fluid being picked up from a cauldron. Requires the display manipulate permission.
+- Protection against signs being dyed or glowed. Requires the sign edit permission.
 
 ### Changed
 - Mob hurt/leash/shear claim permissions merged into the "Husbandry" permission.

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
@@ -54,7 +54,9 @@ enum class ClaimPermission(val parent: ClaimPermission?, val events: Array<Permi
     /**
      * When the sign edit menu is opened.
      */
-    SignEdit(null, arrayOf(PermissionBehaviour.signEditing)),
+    SignEdit(null, arrayOf(
+        PermissionBehaviour.signEditing,
+        PermissionBehaviour.signDyeing)),
 
     /**
      * When a device used to activate redstone is interacted with by a player.

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
@@ -8,6 +8,7 @@ import org.bukkit.block.data.AnaloguePowerable
 import org.bukkit.block.data.Openable
 import org.bukkit.block.data.Powerable
 import org.bukkit.block.data.type.Farmland
+import org.bukkit.block.data.type.Sign
 import org.bukkit.block.data.type.Switch
 import org.bukkit.entity.*
 import org.bukkit.event.Cancellable
@@ -76,6 +77,9 @@ class PermissionBehaviour {
 
         // Used for editing sign text
         val signEditing = PermissionExecutor(PlayerOpenSignEvent::class.java, Companion::cancelEvent, Companion::getPlayerOpenSignLocation, Companion::getPlayerOpenSignPlayer)
+
+        // Used for putting dyes or glow ink on a sign
+        val signDyeing = PermissionExecutor(PlayerInteractEvent::class.java, Companion::cancelSignDyeing, Companion::getInteractEventLocation, Companion::getInteractEventPlayer)
 
         // Used for taking and placing armour from armour stand
         val armorStandManipulate = PermissionExecutor(PlayerArmorStandManipulateEvent::class.java, Companion::cancelEvent, Companion::getArmorStandLocation, Companion::getArmorStandManipulator)
@@ -363,6 +367,18 @@ class PermissionBehaviour {
             if (event !is InventoryOpenEvent) return false
             val t = event.inventory.type
             if (t != InventoryType.MERCHANT) return false
+            event.isCancelled = true
+            return true
+        }
+
+        /**
+         * Cancels the action of applying dye or glow ink to a sign.
+         */
+        private fun cancelSignDyeing(listener: Listener, event: Event): Boolean {
+            if (event !is PlayerInteractEvent) return false
+            if (event.action != Action.RIGHT_CLICK_BLOCK) return false
+            val block = event.clickedBlock ?: return false
+            if (block.blockData !is Sign) return false
             event.isCancelled = true
             return true
         }


### PR DESCRIPTION
Players are able to edit signs using dyes to change the colour as well as use glow ink to make it glow. Protection for this is now handled by the sign edit permission.