### PR TITLE
Added protection against shearing pumpkins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Update to support MC version 1.21
 - Protection against fluid being picked up from the ground. Requires the build permission.
 - Protection against fluid being picked up from a cauldron. Requires the display manipulate permission.
 - Protection against signs being dyed or glowed. Requires the sign edit permission.
+- Protection against pumpkins being sheared. Requires the build permission.
 
 ### Changed
 - Mob hurt/leash/shear claim permissions merged into the "Husbandry" permission.

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
@@ -23,7 +23,8 @@ enum class ClaimPermission(val parent: ClaimPermission?, val events: Array<Permi
         PermissionBehaviour.fertilize,
         PermissionBehaviour.farmlandStep,
         PermissionBehaviour.dragonEggTeleport,
-        PermissionBehaviour.bucketFill
+        PermissionBehaviour.bucketFill,
+        PermissionBehaviour.pumpkinShear
     )),
 
     /**

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
@@ -1,5 +1,6 @@
 package dev.mizarc.bellclaims.interaction.listeners
 
+import io.papermc.paper.event.block.PlayerShearBlockEvent
 import io.papermc.paper.event.player.PlayerFlowerPotManipulateEvent
 import io.papermc.paper.event.player.PlayerOpenSignEvent
 import org.bukkit.Location
@@ -125,6 +126,9 @@ class PermissionBehaviour {
 
         // Used for using a bucket to pick up fluids
         val bucketFill = PermissionExecutor(PlayerBucketFillEvent::class.java, Companion::cancelEvent, Companion::getBucketFillLocation, Companion::getBucketFillPlayer)
+
+        // Used for shearing pumpkins
+        val pumpkinShear = PermissionExecutor(PlayerShearBlockEvent::class.java, Companion::cancelPumpkinShear, Companion::getShearBlockLocation, Companion::getShearBlockPlayer)
 
         /**
          * Cancels any cancellable event.
@@ -383,6 +387,16 @@ class PermissionBehaviour {
             return true
         }
 
+        /**
+         * Cancels the action of shearing a pumpkin.
+         */
+        private fun cancelPumpkinShear(listener: Listener, event: Event): Boolean {
+            if (event !is PlayerShearBlockEvent) return false
+            if (event.block.type != Material.PUMPKIN) return false
+            event.isCancelled = true
+            return true
+        }
+
         private fun getVehicleDestroyPlayer(event: Event): Player? {
             if (event !is VehicleDestroyEvent) return null
             if (event.attacker !is Player) return null
@@ -616,6 +630,16 @@ class PermissionBehaviour {
         private fun getBucketFillLocation(event: Event): Location? {
             if (event !is PlayerBucketFillEvent) return null
             return event.block.location
+        }
+
+        private fun getShearBlockLocation(event: Event): Location? {
+            if (event !is PlayerShearBlockEvent) return null
+            return event.block.location
+        }
+
+        private fun getShearBlockPlayer(event: Event): Player? {
+            if (event !is PlayerShearBlockEvent) return null
+            return event.player
         }
     }
 }


### PR DESCRIPTION
Players were able to shear pumpkins in protected claims. This action is now protected by the build permission, as it is a permanent change to the world.