### PR TITLE
Added protection against beehive harvesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Update to support MC version 1.21
 - Protection against fluid being picked up from a cauldron. Requires the display manipulate permission.
 - Protection against signs being dyed or glowed. Requires the sign edit permission.
 - Protection against pumpkins being sheared. Requires the build permission.
+- Protection against harvesting honey (bottling) and honeycombs (shearing) from beehives. Requires the husbandry permission.
 
 ### Changed
 - Mob hurt/leash/shear claim permissions merged into the "Husbandry" permission.

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
@@ -82,7 +82,8 @@ enum class ClaimPermission(val parent: ClaimPermission?, val events: Array<Permi
         PermissionBehaviour.interactAnimals,
         PermissionBehaviour.fishingRod,
         PermissionBehaviour.takeLeadFromFence,
-        PermissionBehaviour.beehiveShear
+        PermissionBehaviour.beehiveShear,
+        PermissionBehaviour.beehiveBottle
     ));
 
     companion object {

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
@@ -133,6 +133,9 @@ class PermissionBehaviour {
         // Used for shearing beehives
         val beehiveShear = PermissionExecutor(PlayerShearBlockEvent::class.java, Companion::cancelBeehiveShear, Companion::getShearBlockLocation, Companion::getShearBlockPlayer)
 
+        // Used for bottling honey from beehives
+        val beehiveBottle = PermissionExecutor(PlayerInteractEvent::class.java, Companion::cancelBeehiveBottle, Companion::getInteractEventLocation, Companion::getInteractEventPlayer)
+
         /**
          * Cancels any cancellable event.
          */
@@ -406,6 +409,20 @@ class PermissionBehaviour {
         private fun cancelBeehiveShear(listener: Listener, event: Event): Boolean {
             if (event !is PlayerShearBlockEvent) return false
             if (event.block.type != Material.BEEHIVE && event.block.type != Material.BEE_NEST) return false
+            event.isCancelled = true
+            return true
+        }
+
+        /**
+         * Cancels the action putting honey in a bottle from a beehive.
+         */
+        private fun cancelBeehiveBottle(listener: Listener, event: Event): Boolean {
+            if (event !is PlayerInteractEvent) return false
+            if (event.action != Action.RIGHT_CLICK_BLOCK) return false
+            val block = event.clickedBlock ?: return false
+            if (block.type != Material.BEEHIVE && block.type != Material.BEE_NEST) return false
+            val item = event.item ?: return false
+            if (item.type != Material.GLASS_BOTTLE) return false
             event.isCancelled = true
             return true
         }


### PR DESCRIPTION
Player were able to use shears or bottles to harvest honey and honeycombs from beehives. Permission to do this is now behind the husbandry permission.

The first change of shearing hives was accidentally pushed to main by me (oops). Should've been put in this pull request.