### PR TITLE
Added protection against composter usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Update to support MC version 1.21
 - Protection against fluid being picked up from a cauldron. Requires the display manipulate permission.
 - Protection against signs being dyed or glowed. Requires the sign edit permission.
 - Protection against pumpkins being sheared. Requires the build permission.
+- Protection against the usage of composters. Requires the display manipulate permission.
 
 ### Changed
 - Mob hurt/leash/shear claim permissions merged into the "Husbandry" permission.

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
@@ -225,6 +225,7 @@ class PermissionBehaviour {
                 block.type != Material.GLOW_ITEM_FRAME &&
                 block.type != Material.CHISELED_BOOKSHELF &&
                 block.type != Material.JUKEBOX &&
+                block.type != Material.COMPOSTER &&
                 block.type != Material.CAULDRON &&
                 block.type != Material.WATER_CAULDRON &&
                 block.type != Material.LAVA_CAULDRON &&


### PR DESCRIPTION
Players were able to make use of composters inside someone's protected claim. This is now protected behind the display manipulate permission, as it is changing the temporary state of a placed block.