### PR TITLE
Fixed bees unable to produce honey while mob griefing flag is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Update to support MC version 1.21
 
 ### Fixed
 - Inability to break blocks in north or south direction of bell regardless of bell attachment.
+- Bees unable to produce honey since they were affected by the mob griefing filter.
 
 ## [0.1.2]
 Update to support MC Version 1.20.6

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/FlagBehaviour.kt
@@ -15,6 +15,7 @@ import dev.mizarc.bellclaims.api.PartitionService
 import dev.mizarc.bellclaims.domain.claims.Claim
 import dev.mizarc.bellclaims.domain.flags.Flag
 import org.bukkit.entity.ArmorStand
+import org.bukkit.entity.Bee
 import org.bukkit.entity.Creeper
 import org.bukkit.entity.ItemFrame
 import org.bukkit.entity.Painting
@@ -201,6 +202,7 @@ class RuleBehaviour {
                                             partitionService: PartitionService, flagService: FlagService): Boolean {
             if (event !is EntityChangeBlockEvent) return false
             if (event.entity is Player) return false
+            if (event.entity is Bee) return false
             event.isCancelled = true
             return true
         }


### PR DESCRIPTION
Bees should not be affected by mob griefing since the act of producing honey is not a very destructive action. Please let the bees do their work.