### PR TITLE
Fixed falling blocks not falling in claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Update to support MC version 1.21
 ### Fixed
 - Inability to break blocks in north or south direction of bell regardless of bell attachment.
 - Bees unable to produce honey since they were affected by the mob griefing filter.
+- Falling blocks not falling in claims (And potentially other non-monster entities that should be able to change state)
 
 ## [0.1.2]
 Update to support MC Version 1.20.6

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
@@ -22,7 +22,7 @@ enum class Flag(val rules: Array<RuleExecutor>) {
      * When a mob destroys or otherwise changes blocks.
      */
     MobGriefing(arrayOf(
-        RuleBehaviour.mobGriefing,
+        RuleBehaviour.mobBlockChange,
         RuleBehaviour.creeperExplode,
         RuleBehaviour.creeperDamageStaticEntity,
         RuleBehaviour.creeperDamageHangingEntity

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/FlagBehaviour.kt
@@ -15,11 +15,10 @@ import dev.mizarc.bellclaims.api.PartitionService
 import dev.mizarc.bellclaims.domain.claims.Claim
 import dev.mizarc.bellclaims.domain.flags.Flag
 import org.bukkit.entity.ArmorStand
-import org.bukkit.entity.Bee
 import org.bukkit.entity.Creeper
 import org.bukkit.entity.ItemFrame
+import org.bukkit.entity.Monster
 import org.bukkit.entity.Painting
-import org.bukkit.entity.Player
 import org.bukkit.event.entity.EntityDamageByBlockEvent
 import org.bukkit.event.entity.EntityDamageByEntityEvent
 import org.bukkit.event.entity.EntityDamageEvent
@@ -201,8 +200,7 @@ class RuleBehaviour {
         private fun cancelEntityBlockChange(event: Event, claimService: ClaimService,
                                             partitionService: PartitionService, flagService: FlagService): Boolean {
             if (event !is EntityChangeBlockEvent) return false
-            if (event.entity is Player) return false
-            if (event.entity is Bee) return false
+            if (event.entity !is Monster) return false
             event.isCancelled = true
             return true
         }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/FlagBehaviour.kt
@@ -46,7 +46,7 @@ class RuleBehaviour {
             Companion::cancelEvent, Companion::blockInClaim)
         val fireSpread = RuleExecutor(BlockSpreadEvent::class.java,
             Companion::cancelEvent, Companion::fireSpreadInClaim)
-        val mobGriefing = RuleExecutor(EntityChangeBlockEvent::class.java,
+        val mobBlockChange = RuleExecutor(EntityChangeBlockEvent::class.java,
             Companion::cancelEntityBlockChange, Companion::entityGriefInClaim)
         val creeperExplode = RuleExecutor(EntityExplodeEvent::class.java,
             Companion::cancelCreeperExplode, Companion::entityExplosionInClaim)


### PR DESCRIPTION
This deals with issue #19 where sand and other falling block types do not fall in claims. The check for entities changing block state has been modified to be a blacklist of "Monster" rather than a whitelist of allowed types, which should reduce issues like these, but may also open up more issues in the future. Seems like a good enough compromise for now.