### PR TITLE
Added protection against zombies breaking down doors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Update to support MC version 1.21
 - Protection against pumpkins being sheared. Requires the build permission.
 - Protection against the usage of composters. Requires the display manipulate permission.
 - Protection against harvesting honey (bottling) and honeycombs (shearing) from beehives. Requires the husbandry permission.
+- Protection against zombies breaking down doors. Bypassed by the mob griefing flag.
 
 ### Changed
 - Mob hurt/leash/shear claim permissions merged into the "Husbandry" permission.

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
@@ -23,6 +23,7 @@ enum class Flag(val rules: Array<RuleExecutor>) {
      */
     MobGriefing(arrayOf(
         RuleBehaviour.mobBlockChange,
+        RuleBehaviour.mobBreakDoor,
         RuleBehaviour.creeperExplode,
         RuleBehaviour.creeperDamageStaticEntity,
         RuleBehaviour.creeperDamageHangingEntity


### PR DESCRIPTION
Zombies should not be able to break down doors with the "Mob Griefing" flag disabled. With this change zombies can't break down doors but they will still make breaking noises and look like they're breaking down the door. Don't be afraid, they can't get in.