### PR TITLE
Fixed items being consumed by menu from shift clicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Update to support MC version 1.21
 - Inability to break blocks in north or south direction of bell regardless of bell attachment.
 - Bees unable to produce honey since they were affected by the mob griefing filter.
 - Falling blocks not falling in claims (And potentially other non-monster entities that should be able to change state)
-- Shift clicking items from inventory into menu, which you can't get back.
+- GUIs consuming items shift clicked into them.
 
 ## [0.1.2]
 Update to support MC Version 1.20.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Update to support MC version 1.21
 ### Fixed
 - Inability to break blocks in north or south direction of bell regardless of bell attachment.
 - Bees unable to produce honey since they were affected by the mob griefing filter.
+- Shift clicking items from inventory into menu, which you can't get back.
 
 ## [0.1.2]
 Update to support MC Version 1.20.6

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/ClaimListMenu.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/ClaimListMenu.kt
@@ -10,6 +10,7 @@ import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 import dev.mizarc.bellclaims.utils.lore
 import dev.mizarc.bellclaims.utils.name
+import org.bukkit.event.inventory.ClickType
 import kotlin.math.ceil
 
 class ClaimListMenu(private val claimService: ClaimService, private val player: Player) {
@@ -19,6 +20,7 @@ class ClaimListMenu(private val claimService: ClaimService, private val player: 
         val claims = claimService.getByPlayer(player)
         val gui = ChestGui(6, "Claims")
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
 
         // Add controls pane
         val controlsPane = StaticPane(0, 0, 9, 1)

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/ClaimManagementMenu.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/ClaimManagementMenu.kt
@@ -19,6 +19,7 @@ import dev.mizarc.bellclaims.infrastructure.getClaimMoveTool
 import dev.mizarc.bellclaims.domain.permissions.ClaimPermission
 import dev.mizarc.bellclaims.domain.flags.Flag
 import dev.mizarc.bellclaims.utils.*
+import org.bukkit.event.inventory.ClickType
 import kotlin.concurrent.thread
 import kotlin.math.ceil
 
@@ -43,6 +44,7 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         val gui = ChestGui(1, "Claim Creation")
         val pane = StaticPane(0, 0, 9, 1)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
         gui.addPane(pane)
 
         // Check if player doesn't have enough claims
@@ -83,6 +85,7 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         // Create homes menu
         val gui = AnvilGui("Naming Claim")
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
 
         // Add lodestone menu item
         val firstPane = StaticPane(0, 0, 1, 1)
@@ -127,6 +130,7 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         val gui = ChestGui(1, "Claim '${claim.name}'")
         val pane = StaticPane(0, 0, 9, 1)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
         gui.addPane(pane)
 
         // Add claim tool button
@@ -206,6 +210,7 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         val gui = FurnaceGui("Set Warp Icon")
         val fuelPane = StaticPane(0, 0, 1, 1)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
 
         // Add info paper menu item
         val paperItem = ItemStack(Material.PAPER)
@@ -262,6 +267,7 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         // Create homes menu
         val gui = AnvilGui("Renaming Claim")
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
 
         // Add lodestone menu item
         val firstPane = StaticPane(0, 0, 1, 1)
@@ -312,6 +318,7 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         // Create claim flags menu
         val gui = ChestGui(4, "Claim Flags")
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
 
         // Add controls pane
         val controlsPane = StaticPane(0, 0, 9, 1)
@@ -418,6 +425,7 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         // Create trust menu
         val gui = ChestGui(6, "Trusted Players")
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
 
         // Add controls pane
         val controlsPane = addControlsSection(gui) { openClaimEditMenu(claim) }
@@ -466,6 +474,7 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         // Create player permissions menu
         val gui = ChestGui(6, "${player.name}'s Permissions")
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
 
         // Add controls pane
         val controlsPane = addControlsSection(gui) { openClaimTrustMenu(claim, 0) }
@@ -550,6 +559,7 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         // Create player permissions menu
         val gui = ChestGui(6, "Default Claim Permissions")
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
 
         // Add controls
         val controlsPane = addControlsSection(gui) { openClaimTrustMenu(claim, 0) }
@@ -638,6 +648,7 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         // Create trust menu
         val gui = ChestGui(6, "All Players")
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
 
         // Add controls
         val controlsPane = addControlsSection(gui) { openClaimTrustMenu(claim, 0) }
@@ -682,6 +693,7 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         // Create homes menu
         val gui = AnvilGui("Search for Player")
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
 
         // Add lodestone menu item
         val firstPane = StaticPane(0, 0, 1, 1)

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/EditToolMenu.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/EditToolMenu.kt
@@ -15,6 +15,7 @@ import dev.mizarc.bellclaims.domain.partitions.Partition
 import dev.mizarc.bellclaims.interaction.visualisation.Visualiser
 import dev.mizarc.bellclaims.utils.lore
 import dev.mizarc.bellclaims.utils.name
+import org.bukkit.event.inventory.ClickType
 
 class EditToolMenu(private val claimService: ClaimService, private val partitionService: PartitionService,
                    private val playerStateService: PlayerStateService, private val player: Player,
@@ -22,6 +23,7 @@ class EditToolMenu(private val claimService: ClaimService, private val partition
     fun openEditToolMenu() {
         val gui = ChestGui(1, "Claim Tool")
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
 
         val pane = StaticPane(0, 0, 9, 1)
         gui.addPane(pane)
@@ -122,6 +124,7 @@ class EditToolMenu(private val claimService: ClaimService, private val partition
         val gui = HopperGui("Delete Partition?")
         val pane = StaticPane(1, 0, 3, 1)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
         gui.slotsComponent.addPane(pane)
 
         // Add no menu item


### PR DESCRIPTION
Players would have their items taken by the menu and deleted after shift clicking it into the menu. This simply blocks all shift click events on the player's own inventory, but needs to be done for every single menu created in the future.