### PR TITLE
Added protections against various types of explosives in a new "Detonate" permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 Update to support MC version 1.21
 
 ### Added
-- Protection against players breeding animals. Requires the husbandry permission.
+- Protection against players breeding animals. Requires the new husbandry permission.
+- Protection against TNT being ignited by flint and steel or burning projectiles. Requires the new detonate permission.
+- Protection against end crystals being blown up. Requires the new detonate permission.
 - Protection against players right-clicking dragon eggs, causing it to teleport. Requires the build permission.
 - Protection against fluid being picked up from the ground. Requires the build permission.
 - Protection against fluid being picked up from a cauldron. Requires the display manipulate permission.
@@ -17,6 +19,7 @@ Update to support MC version 1.21
 - Protection against the usage of composters. Requires the display manipulate permission.
 - Protection against harvesting honey (bottling) and honeycombs (shearing) from beehives. Requires the husbandry permission.
 - Protection against zombies breaking down doors. Bypassed by the mob griefing flag.
+- Protection against projectile based weaponry, applied to any permission that protects entities.
 
 ### Changed
 - Mob hurt/leash/shear claim permissions merged into the "Husbandry" permission.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Update to support MC version 1.21
 ### Added
 - Protection against players breeding animals. Requires the new husbandry permission.
 - Protection against TNT being ignited by flint and steel or burning projectiles. Requires the new detonate permission.
+- Protection against exploding beds and respawn anchors when used outside of their intended dimension. Requires the new detonate permission.
 - Protection against end crystals being blown up. Requires the new detonate permission.
 - Protection against players right-clicking dragon eggs, causing it to teleport. Requires the build permission.
 - Protection against fluid being picked up from the ground. Requires the build permission.

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
@@ -93,7 +93,8 @@ enum class ClaimPermission(val parent: ClaimPermission?, val events: Array<Permi
         PermissionBehaviour.primeTNT,
         PermissionBehaviour.detonateEndCrystal,
         PermissionBehaviour.detonateBed,
-        PermissionBehaviour.detonateRespawnAnchor
+        PermissionBehaviour.detonateRespawnAnchor,
+        PermissionBehaviour.detonateTNTMinecart
     ));
 
     companion object {

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
@@ -91,7 +91,9 @@ enum class ClaimPermission(val parent: ClaimPermission?, val events: Array<Permi
      */
     Detonate(null, arrayOf(
         PermissionBehaviour.primeTNT,
-        PermissionBehaviour.detonateEndCrystal
+        PermissionBehaviour.detonateEndCrystal,
+        PermissionBehaviour.detonateBed,
+        PermissionBehaviour.detonateRespawnAnchor
     ));
 
     companion object {

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
@@ -84,6 +84,13 @@ enum class ClaimPermission(val parent: ClaimPermission?, val events: Array<Permi
         PermissionBehaviour.takeLeadFromFence,
         PermissionBehaviour.beehiveShear,
         PermissionBehaviour.beehiveBottle
+    )),
+
+    /**
+     * When an explosive is detonated by a player.
+     */
+    Detonate(null, arrayOf(
+        PermissionBehaviour.primeTNT
     ));
 
     companion object {

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
@@ -90,7 +90,8 @@ enum class ClaimPermission(val parent: ClaimPermission?, val events: Array<Permi
      * When an explosive is detonated by a player.
      */
     Detonate(null, arrayOf(
-        PermissionBehaviour.primeTNT
+        PermissionBehaviour.primeTNT,
+        PermissionBehaviour.detonateEndCrystal
     ));
 
     companion object {

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
@@ -440,12 +440,18 @@ class PermissionBehaviour {
             return true
         }
 
+        /**
+         * Cancels the action of priming tnt with flint and steel or arrows.
+         */
         private fun cancelTNTPrime(listener: Listener, event: Event): Boolean {
             if (event !is TNTPrimeEvent) return false
             event.isCancelled = true
             return true
         }
 
+        /**
+         * Cancels the action of blowing up and end crystal by damaging it.
+         */
         private fun cancelEndCrystalDamage(listener: Listener, event: Event): Boolean {
             if (event !is EntityDamageByEntityEvent) return false
             if (event.entity !is EnderCrystal) return false
@@ -453,6 +459,9 @@ class PermissionBehaviour {
             return true
         }
 
+        /**
+         * Cancels the action of blowing up a bed by interacting with it outside of the overworld.
+         */
         private fun cancelBedExplode(listener: Listener, event: Event): Boolean {
             if (event !is PlayerInteractEvent) return false
             val clickedBlock = event.clickedBlock ?: return false
@@ -462,6 +471,9 @@ class PermissionBehaviour {
             return true
         }
 
+        /**
+         * Cancels the action of blowing up a respawn anchor by interacting with it outside of the nether.
+         */
         private fun cancelRespawnAnchorExplode(listener: Listener, event: Event): Boolean {
             if (event !is PlayerInteractEvent) return false
             val clickedBlock = event.clickedBlock ?: return false

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
@@ -139,6 +139,9 @@ class PermissionBehaviour {
         // Used for priming TNT by hand or burning arrow
         val primeTNT = PermissionExecutor(TNTPrimeEvent::class.java, Companion::cancelTNTPrime, Companion::getTNTPrimeLocation, Companion::getTNTPrimePlayer)
 
+        // Used for detonating end crystals by causing damage to it
+        val detonateEndCrystal = PermissionExecutor(EntityDamageByEntityEvent::class.java, Companion::cancelEndCrystalDamage, Companion::getEntityDamageByEntityLocation, Companion::getEntityDamageSourcePlayer)
+
         /**
          * Cancels any cancellable event.
          */
@@ -433,6 +436,13 @@ class PermissionBehaviour {
 
         private fun cancelTNTPrime(listener: Listener, event: Event): Boolean {
             if (event !is TNTPrimeEvent) return false
+            event.isCancelled = true
+            return true
+        }
+
+        private fun cancelEndCrystalDamage(listener: Listener, event: Event): Boolean {
+            if (event !is EntityDamageByEntityEvent) return false
+            if (event.entity !is EnderCrystal) return false
             event.isCancelled = true
             return true
         }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
@@ -433,7 +433,6 @@ class PermissionBehaviour {
 
         private fun cancelTNTPrime(listener: Listener, event: Event): Boolean {
             if (event !is TNTPrimeEvent) return false
-            if (event.cause != TNTPrimeEvent.PrimeCause.PLAYER) return false
             event.isCancelled = true
             return true
         }
@@ -691,8 +690,15 @@ class PermissionBehaviour {
         private fun getTNTPrimePlayer(event: Event): Player? {
             if (event !is TNTPrimeEvent) return null
             val primingEntity = event.primingEntity ?: return null
-            if (primingEntity !is Player) return null
-            return primingEntity
+            if (primingEntity is Projectile) {
+                if (primingEntity.shooter is Player) {
+                    return primingEntity.shooter as Player
+                }
+            }
+            if (primingEntity is Player) {
+                return primingEntity
+            }
+            return null
         }
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
@@ -136,6 +136,9 @@ class PermissionBehaviour {
         // Used for bottling honey from beehives
         val beehiveBottle = PermissionExecutor(PlayerInteractEvent::class.java, Companion::cancelBeehiveBottle, Companion::getInteractEventLocation, Companion::getInteractEventPlayer)
 
+        // Used for priming TNT by hand or burning arrow
+        val primeTNT = PermissionExecutor(TNTPrimeEvent::class.java, Companion::cancelTNTPrime, Companion::getTNTPrimeLocation, Companion::getTNTPrimePlayer)
+
         /**
          * Cancels any cancellable event.
          */
@@ -428,6 +431,13 @@ class PermissionBehaviour {
             return true
         }
 
+        private fun cancelTNTPrime(listener: Listener, event: Event): Boolean {
+            if (event !is TNTPrimeEvent) return false
+            if (event.cause != TNTPrimeEvent.PrimeCause.PLAYER) return false
+            event.isCancelled = true
+            return true
+        }
+
         private fun getVehicleDestroyPlayer(event: Event): Player? {
             if (event !is VehicleDestroyEvent) return null
             if (event.attacker !is Player) return null
@@ -671,6 +681,18 @@ class PermissionBehaviour {
         private fun getShearBlockPlayer(event: Event): Player? {
             if (event !is PlayerShearBlockEvent) return null
             return event.player
+        }
+
+        private fun getTNTPrimeLocation(event: Event): Location? {
+            if (event !is TNTPrimeEvent) return null
+            return event.block.location
+        }
+
+        private fun getTNTPrimePlayer(event: Event): Player? {
+            if (event !is TNTPrimeEvent) return null
+            val primingEntity = event.primingEntity ?: return null
+            if (primingEntity !is Player) return null
+            return primingEntity
         }
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/utils/PermissionDisplay.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/utils/PermissionDisplay.kt
@@ -1,8 +1,10 @@
 package dev.mizarc.bellclaims.utils
 
+import dev.mizarc.bellclaims.domain.claims.Claim
 import org.bukkit.Material
 import org.bukkit.inventory.ItemStack
 import dev.mizarc.bellclaims.domain.permissions.ClaimPermission
+import org.bukkit.entity.Item
 
 /**
  * Associates claim permissions with a specific in-game item.
@@ -20,6 +22,7 @@ fun ClaimPermission.getIcon(): ItemStack {
         ClaimPermission.DoorOpen -> ItemStack(Material.ACACIA_DOOR)
         ClaimPermission.VillagerTrade -> ItemStack(Material.EMERALD)
         ClaimPermission.Husbandry -> ItemStack(Material.LEAD)
+        ClaimPermission.Detonate -> ItemStack(Material.TNT)
     }
 }
 
@@ -39,6 +42,7 @@ fun ClaimPermission.getDisplayName(): String {
         ClaimPermission.DoorOpen -> "Door Open"
         ClaimPermission.VillagerTrade -> "Villager Trade"
         ClaimPermission.Husbandry -> "Husbandry"
+        ClaimPermission.Detonate -> "Detonate"
     }
 }
 
@@ -58,5 +62,6 @@ fun ClaimPermission.getDescription(): String {
         ClaimPermission.DoorOpen -> "Grants permission to open and close doors"
         ClaimPermission.VillagerTrade -> "Grants permission to trade with villagers"
         ClaimPermission.Husbandry -> "Grants permission to interact with passive animals"
+        ClaimPermission.Detonate -> "Grants permission to directly set off explosives"
     }
 }


### PR DESCRIPTION
Here are all the things players were able to do prior to the addition of this permission:
- Use flint and steel on tnt.
- Shoot tnt with flaming projectile.
- Shoot minecart tnt with flaming projectile.
- Damage end crystal causing it to explode.
- Use bed outside of the overworld causing it to explode.
- Use respawn anchor outside of the nether causing it to explode.

This request puts all of these actions into the one "Detonate" permissions that claim owners can specifically grant to players.