### PR TITLE
Added protection for cake eating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Update to support MC version 1.21
 - Protection against pumpkins being sheared. Requires the build permission.
 - Protection against the usage of composters. Requires the display manipulate permission.
 - Protection against harvesting honey (bottling) and honeycombs (shearing) from beehives. Requires the husbandry permission.
+- Protection against eating cakes. Requires the display manipulate permission.
 
 ### Changed
 - Mob hurt/leash/shear claim permissions merged into the "Husbandry" permission.

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
@@ -232,7 +232,8 @@ class PermissionBehaviour {
                 block.type != Material.CAULDRON &&
                 block.type != Material.WATER_CAULDRON &&
                 block.type != Material.LAVA_CAULDRON &&
-                block.type != Material.POWDER_SNOW_CAULDRON) return false
+                block.type != Material.POWDER_SNOW_CAULDRON &&
+                block.type != Material.CAKE) return false
             event.isCancelled = true
             return true
         }


### PR DESCRIPTION
Players should not be able to eat cake without permission. The current permission it is set to is "Display Manipulate", but this is a little contested since eating a cake removes it from the world, while other display manipulate accesses are reversible. "Build" doesn't really make sense either though since needing to give someone build permissions just to eat cake seems overkill. This is a good placement for now.