### PR TITLE
Change the display name of permissions to use verbs first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,17 +14,18 @@ Update to support MC version 1.21
 - Protection against end crystals being blown up. Requires the new detonate permission.
 - Protection against players right-clicking dragon eggs, causing it to teleport. Requires the build permission.
 - Protection against fluid being picked up from the ground. Requires the build permission.
-- Protection against fluid being picked up from a cauldron. Requires the display manipulate permission.
+- Protection against fluid being picked up from a cauldron. Requires the manipulate permission.
 - Protection against signs being dyed or glowed. Requires the sign edit permission.
 - Protection against pumpkins being sheared. Requires the build permission.
 - Protection against the usage of composters. Requires the display manipulate permission.
 - Protection against harvesting honey (bottling) and honeycombs (shearing) from beehives. Requires the husbandry permission.
 - Protection against zombies breaking down doors. Bypassed by the mob griefing flag.
 - Protection against projectile based weaponry, applied to any permission that protects entities.
-- Protection against eating cakes. Requires the display manipulate permission.
+- Protection against eating cakes. Requires the manipulate permission.
 
 ### Changed
 - Mob hurt/leash/shear claim permissions merged into the "Husbandry" permission.
+- Permissions have their display names modified to be verb before noun. Some names simplified such as "Display Manipulate" to just "Manipulate".
 
 ### Fixed
 - Inability to break blocks in north or south direction of bell regardless of bell attachment.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ As for being on the team to be able to contribute directly, contact me first and
 Branches are laid out in a pretty straightforward way.
 - `main` holds the lastest development release. Ensure that it is able to be run at all costs. Do not commit to this directly.
 - `feature/` prefix is for adding new or improving upon existing features.
+- `tweak/` prefix is for tweaking existing functionality values.
 - `fix/` prefix is for non-urgent bugs or bugs that may take an extended time to repair.
 - `hotfix/` prefix is for urgent bugs that should be worked on ASAP and sent to the next patch release.
 - `release/` prefix is for maintaining an older feature release, usually to send out bug fixes.

--- a/src/main/kotlin/dev/mizarc/bellclaims/utils/PermissionDisplay.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/utils/PermissionDisplay.kt
@@ -34,13 +34,13 @@ fun ClaimPermission.getIcon(): ItemStack {
 fun ClaimPermission.getDisplayName(): String {
     return when (this) {
         ClaimPermission.Build -> "Build"
-        ClaimPermission.ContainerInspect -> "Container Inspect"
-        ClaimPermission.DisplayManipulate -> "Display Manipulate"
-        ClaimPermission.VehicleDeploy -> "Vehicle Deploy"
-        ClaimPermission.SignEdit -> "Sign Edit"
-        ClaimPermission.RedstoneInteract -> "Redstone Interact"
-        ClaimPermission.DoorOpen -> "Door Open"
-        ClaimPermission.VillagerTrade -> "Villager Trade"
+        ClaimPermission.ContainerInspect -> "Inspect Containers"
+        ClaimPermission.DisplayManipulate -> "Manipulate"
+        ClaimPermission.VehicleDeploy -> "Deploy Vehicles"
+        ClaimPermission.SignEdit -> "Edit Signs"
+        ClaimPermission.RedstoneInteract -> "Trigger Redstone"
+        ClaimPermission.DoorOpen -> "Open Doors"
+        ClaimPermission.VillagerTrade -> "Trade Villagers"
         ClaimPermission.Husbandry -> "Husbandry"
         ClaimPermission.Detonate -> "Detonate"
     }


### PR DESCRIPTION
This sounds more natural for the end user and less like an internal name. Notable changes include:
- Sign Edit -> Edit Signs
- Villager Trade -> Trade Villagers
- Vehicle Deploy -> Deploy Vehicles

Display Manipulate has also been simplified to just Manipulate.