### PR TITLE
Show claim block remaining amount on claim resizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 Update to support MC version 1.21
 
 ### Added
+- Amount of blocks remaining now displays when a corner resize action is started and finalised.
+- Warning message when partition creation would result in it not connected to the claim.
 - Protection against players breeding animals. Requires the new husbandry permission.
 - Protection against TNT being ignited by flint and steel or burning projectiles. Requires the new detonate permission.
 - Protection against exploding beds and respawn anchors when used outside of their intended dimension. Requires the new detonate permission.
@@ -32,6 +34,7 @@ Update to support MC version 1.21
 - Bees unable to produce honey since they were affected by the mob griefing filter.
 - Falling blocks not falling in claims (And potentially other non-monster entities that should be able to change state)
 - GUIs consuming items shift clicked into them.
+- Amount remaining on display incorrect when claim resize larger than the amount of blocks players have left.
 
 ## [0.1.2]
 Update to support MC Version 1.20.6

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/partitions/Partition.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/partitions/Partition.kt
@@ -130,8 +130,8 @@ data class Partition(var id: UUID, var claimId: UUID, var area: Area) {
         fun getExtraBlockCount(): Int {
             return ((newArea.upperPosition2D.x - newArea.lowerPosition2D.x + 1) *
                     (newArea.upperPosition2D.z - newArea.lowerPosition2D.z + 1)).absoluteValue -
-                    ((partition.area.upperPosition2D.x - partition.area.upperPosition2D.x + 1) *
-                    (partition.area.upperPosition2D.z - partition.area.upperPosition2D.z+ 1)).absoluteValue
+                    ((partition.area.upperPosition2D.x - partition.area.lowerPosition2D.x + 1) *
+                    (partition.area.upperPosition2D.z - partition.area.lowerPosition2D.z + 1)).absoluteValue
         }
 
         /**

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolListener.kt
@@ -176,9 +176,9 @@ class EditToolListener(private val claims: ClaimRepository,
                 player.sendActionBar(Component.text("New partition has been added to " +
                         claims.getById(partition.claimId)!!.name)
                     .color(TextColor.color(255, 85, 85)))
-
-
-            PartitionCreationResult.NOT_CONNECTED -> TODO()
+            PartitionCreationResult.NOT_CONNECTED -> player.sendActionBar(Component.text("That selection is " +
+                    "not connected to your claim.")
+                .color(TextColor.color(255, 85, 85)))
         }
 
         // Update builders list and visualisation

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolListener.kt
@@ -215,8 +215,10 @@ class EditToolListener(private val claims: ClaimRepository,
         }
 
         partitionResizers[player] = Partition.Resizer(partition, Position2D(location))
+        val remainingClaimBlockCount = playerLimitService.getRemainingClaimBlockCount(player)
         player.sendActionBar(
-            Component.text("Claim corner selected. Select a different location to resize the claim.")
+            Component.text("Claim corner selected. Select a different location to resize. " +
+                    "You have $remainingClaimBlockCount blocks remaining.")
                 .color(TextColor.color(85, 255, 85)))
         return true
     }
@@ -257,7 +259,7 @@ class EditToolListener(private val claims: ClaimRepository,
             PartitionResizeResult.SUCCESS ->
                 player.sendActionBar(
                     Component.text("Claim partition successfully resized. " +
-                            "You have " + newRemainingClaimBlockCount + " blocks remaining.")
+                            "You have $newRemainingClaimBlockCount blocks remaining.")
                         .color(TextColor.color(85, 255, 85)))
         }
 


### PR DESCRIPTION
There's no way of knowing how many claim blocks you have left until the selection you're making is too large. This addresses the issue by adding the remaining amount on any claim block resize action.

The display amount was also incorrect when the claim resize was too large and the player did not have enough blocks, which has also been fixed.