### PR TITLE
Added ability to break claim bells with claim override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Update to support MC version 1.21
 ### Added
 - Amount of blocks remaining now displays when a corner resize action is started and finalised.
 - Warning message when partition creation would result in it not connected to the claim.
+- Ability to break claim bells owned by other players using claim override.
 - Protection against players breeding animals. Requires the new husbandry permission.
 - Protection against TNT being ignited by flint and steel or burning projectiles. Requires the new detonate permission.
 - Protection against exploding beds and respawn anchors when used outside of their intended dimension. Requires the new detonate permission.

--- a/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
@@ -175,7 +175,8 @@ class BellClaims : JavaPlugin() {
         server.pluginManager.registerEvents(EditToolRemovalListener(), this)
         server.pluginManager.registerEvents(ClaimBellListener(claimService, claimWorldService, flagService,
             defaultPermissionService, playerPermissionService, playerLimitService), this)
-        server.pluginManager.registerEvents(ClaimDestructionListener(claimService, claimWorldService), this)
+        server.pluginManager.registerEvents(ClaimDestructionListener(claimService, claimWorldService,
+            playerStateService), this)
         server.pluginManager.registerEvents(MoveToolListener(claimRepo, partitionService), this)
         server.pluginManager.registerEvents(MoveToolRemovalListener(), this)
         server.pluginManager.registerEvents(MiscPreventionsListener(claimService, partitionService), this)

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimDestructionListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimDestructionListener.kt
@@ -9,6 +9,7 @@ import org.bukkit.event.Listener
 import org.bukkit.event.block.BlockBreakEvent
 import dev.mizarc.bellclaims.api.ClaimService
 import dev.mizarc.bellclaims.api.ClaimWorldService
+import dev.mizarc.bellclaims.api.PlayerStateService
 import dev.mizarc.bellclaims.domain.partitions.Position3D
 import org.bukkit.block.Block
 import org.bukkit.block.BlockFace
@@ -24,14 +25,18 @@ import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.event.world.StructureGrowEvent
 
 class ClaimDestructionListener(val claimService: ClaimService,
-                               private val claimWorldService: ClaimWorldService): Listener {
+                               private val claimWorldService: ClaimWorldService,
+                               private val playerStateService: PlayerStateService
+): Listener {
     @EventHandler
     fun onClaimHubDestroy(event: BlockBreakEvent) {
         if (event.block.blockData !is Bell) return
         val claim = claimWorldService.getByLocation(event.block.location) ?: return
 
+        val playerState = playerStateService.getByPlayer(event.player)
+
         // No permission to break bell
-        if (event.player.uniqueId != claim.owner.uniqueId) {
+        if (event.player.uniqueId != claim.owner.uniqueId && playerState?.claimOverride != true) {
             event.player.sendActionBar(
                 Component.text("This claim belongs to ${claim.owner.name}")
                     .color(TextColor.color(255, 85, 85)))


### PR DESCRIPTION
Server moderators need a way to get rid of claim bells that are owned by other players. This allows bells to be broken the same way as usual when the claim override is being used.