### PR TITLE
Hotfix for database permission enum errors on launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [0.2.1]
+
+### Fixed
+- Existing permission enums that no longer exist but are present in database causing plugin to fail to load.
+
+Note for migrations from pre 0.2 versions: Players will need to add the new Husbandry permission in place of the old Mob permissions. There will be residue in the database as "MobHurt", "MobLeash", and "MobShear" permissions are no longer used. You are free to remove these.
+
 ## [0.2.0]
 Update to support MC version 1.21
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "dev.mizarc"
-version = "0.2.0"
+version = "0.2.1"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/persistence/claims/ClaimPermissionRepositorySQLite.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/persistence/claims/ClaimPermissionRepositorySQLite.kt
@@ -86,8 +86,13 @@ class ClaimPermissionRepositorySQLite(private val storage: SQLiteStorage): Claim
     private fun preload() {
         val results = storage.connection.getResults("SELECT * FROM claimPermissions")
         for (result in results) {
-            val permission = ClaimPermission.valueOf(result.getString("permission"))
-            permissions.getOrPut(UUID.fromString(result.getString("claimId"))) { mutableSetOf() }.add(permission)
+            try {
+                val permission = ClaimPermission.valueOf(result.getString("permission"))
+                permissions.getOrPut(UUID.fromString(result.getString("claimId"))) { mutableSetOf() }.add(permission)
+            }
+            catch (error: IllegalArgumentException) {
+                continue
+            }
         }
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/persistence/claims/PlayerAccessRepositorySQLite.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/persistence/claims/PlayerAccessRepositorySQLite.kt
@@ -92,10 +92,15 @@ class PlayerAccessRepositorySQLite(private val storage: SQLiteStorage): PlayerAc
         for (result in results) {
             val playerId = UUID.fromString(result.getString("playerId"))
             val claimId = UUID.fromString(result.getString("claimId"))
-            val permission = ClaimPermission.valueOf(result.getString("permission"))
-            val claimPlayers = playerAccess
-                .getOrPut(claimId) { mutableMapOf(playerId to mutableSetOf()) }
-            claimPlayers.getOrPut(playerId) { mutableSetOf() }.add(permission)
+            try {
+                val permission = ClaimPermission.valueOf(result.getString("permission"))
+                val claimPlayers = playerAccess
+                    .getOrPut(claimId) { mutableMapOf(playerId to mutableSetOf()) }
+                claimPlayers.getOrPut(playerId) { mutableSetOf() }.add(permission)
+            }
+            catch (error: IllegalArgumentException) {
+                continue
+            }
         }
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: BellClaims
-version: 0.2.0
+version: 0.2.1
 api-version: '1.21'
 main: dev.mizarc.bellclaims.BellClaims
 softdepend: [Vault]


### PR DESCRIPTION
Since the permissions "MobHurt", "MobShear", and "MobLeash" do not exist anymore, loading from the database creates errors which prevents the plugin from loading outright.

These values will remain in database, but will be ignored. Players are expected to replace their existing claims with the Husbandry permission manually. Nothing will be replaced to keep it safe.