### PR TITLE
Fixed item frame protections not being fully effective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [Patch]
+
+### Fixed
+- Glow item frames can be placed in protected claims and items can also be placed in said frames, despite item removal affecting both normal and glow item frames.
+- Missed projectile protection for item frames.
+
 ## [0.2.1]
 
 ### Fixed

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
@@ -225,7 +225,8 @@ class PermissionBehaviour {
          */
         private fun cancelMiscEntityDisplayInteractions(listener: Listener, event: Event): Boolean {
             if (event !is PlayerInteractEntityEvent) return false
-            if (event.rightClicked.type != EntityType.ITEM_FRAME) return false
+            if (event.rightClicked.type != EntityType.ITEM_FRAME &&
+                event.rightClicked.type != EntityType.GLOW_ITEM_FRAME) return false
             event.isCancelled = true
             return true
         }
@@ -281,7 +282,7 @@ class PermissionBehaviour {
             if (event !is PlayerInteractEvent) return false
             if (event.action != Action.RIGHT_CLICK_BLOCK) return false
             val item = event.item ?: return false
-            if (item.type != Material.ITEM_FRAME) return false
+            if (item.type != Material.ITEM_FRAME && item.type != Material.GLOW_ITEM_FRAME) return false
             event.isCancelled = true
             return true
         }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
@@ -334,7 +334,6 @@ class PermissionBehaviour {
          */
         private fun cancelStaticEntityDamage(listener: Listener, event: Event): Boolean {
             if (event !is EntityDamageByEntityEvent) return false
-            if (event.damager !is Player) return false
             if (event.entity !is ItemFrame && event.entity !is GlowItemFrame) return false
             event.isCancelled = true
             return true


### PR DESCRIPTION
Item frames were not protected against projectiles since an incorrect check was added which bypassed the projectile protections that were added last major version.

Glow item frames had even less protections since there were no checks for placing frames in claims as well as putting items into the frames.