### PR TITLE
Fixed unable to break redstone despite having build permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [Patch]
+
+### Fixed
+- Inability to break redstone when player has the build permission but doesn't have the redstone permission.
+
 ## [0.2.1]
 
 ### Fixed

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
@@ -355,6 +355,7 @@ class PermissionBehaviour {
          */
         private fun cancelRedstoneInteract(listener: Listener, event: Event): Boolean {
             if (event !is PlayerInteractEvent) return false
+            if (event.action == Action.LEFT_CLICK_BLOCK) return false
             val block = event.clickedBlock ?: return false
 
             // Block is of type switch, analogue powerable, or a powerable that isn't a door


### PR DESCRIPTION
Since redstone is also handled by its own permission, the ability to break it was also handled as part of the redstone permission, despite being able to place redstone with the build permission. Redstone placing and breaking is now fully handled by the build permission.