### PR TITLE
Added new raid protection permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [Latest]
+
+### Added
+- Protection against players triggering a raid through a bad omen effect. Requires the new raid permission.
+
 ## [0.2.0]
 Update to support MC version 1.21
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
@@ -95,6 +95,13 @@ enum class ClaimPermission(val parent: ClaimPermission?, val events: Array<Permi
         PermissionBehaviour.detonateBed,
         PermissionBehaviour.detonateRespawnAnchor,
         PermissionBehaviour.detonateTNTMinecart
+    )),
+
+    /**
+     * When an event is triggered by an omen effect.
+     */
+    EventStart(null, arrayOf(
+        PermissionBehaviour.triggerRaid
     ));
 
     companion object {

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
@@ -24,6 +24,7 @@ import org.bukkit.event.block.*
 import org.bukkit.event.entity.EntityDamageByEntityEvent
 import org.bukkit.event.entity.EntityPlaceEvent
 import org.bukkit.event.entity.ProjectileHitEvent
+import org.bukkit.event.entity.TrialSpawnerSpawnEvent
 import org.bukkit.event.hanging.HangingBreakByEntityEvent
 import org.bukkit.event.inventory.InventoryOpenEvent
 import org.bukkit.event.inventory.InventoryType

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
@@ -28,6 +28,7 @@ import org.bukkit.event.hanging.HangingBreakByEntityEvent
 import org.bukkit.event.inventory.InventoryOpenEvent
 import org.bukkit.event.inventory.InventoryType
 import org.bukkit.event.player.*
+import org.bukkit.event.raid.RaidTriggerEvent
 import org.bukkit.event.vehicle.VehicleDestroyEvent
 
 /**
@@ -156,6 +157,9 @@ class PermissionBehaviour {
 
         // Used for exploding TNT minecarts with a flaming projectile.
         val detonateTNTMinecart = PermissionExecutor(ProjectileHitEvent::class.java, Companion::cancelTNTMinecartExplode, Companion::getProjectileHitLocation, Companion::getProjectileHitPlayer)
+
+        // Used for events triggered by an omen status effect
+        val triggerRaid = PermissionExecutor(RaidTriggerEvent::class.java, Companion::cancelEvent, Companion::getRaidTriggerLocation, Companion::getRaidTriggerPlayer)
 
         /**
          * Cancels any cancellable event.
@@ -766,6 +770,16 @@ class PermissionBehaviour {
                 return event.entity.shooter as Player
             }
             return null
+        }
+
+        private fun getRaidTriggerLocation(event: Event): Location? {
+            if (event !is RaidTriggerEvent) return null
+            return event.raid.location
+        }
+
+        private fun getRaidTriggerPlayer(event: Event): Player? {
+            if (event !is RaidTriggerEvent) return null
+            return event.player
         }
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/utils/PermissionDisplay.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/utils/PermissionDisplay.kt
@@ -23,6 +23,7 @@ fun ClaimPermission.getIcon(): ItemStack {
         ClaimPermission.VillagerTrade -> ItemStack(Material.EMERALD)
         ClaimPermission.Husbandry -> ItemStack(Material.LEAD)
         ClaimPermission.Detonate -> ItemStack(Material.TNT)
+        ClaimPermission.EventStart -> ItemStack(Material.OMINOUS_BOTTLE)
     }
 }
 
@@ -43,6 +44,7 @@ fun ClaimPermission.getDisplayName(): String {
         ClaimPermission.VillagerTrade -> "Trade Villagers"
         ClaimPermission.Husbandry -> "Husbandry"
         ClaimPermission.Detonate -> "Detonate"
+        ClaimPermission.EventStart -> "Omen"
     }
 }
 
@@ -63,5 +65,6 @@ fun ClaimPermission.getDescription(): String {
         ClaimPermission.VillagerTrade -> "Grants permission to trade with villagers"
         ClaimPermission.Husbandry -> "Grants permission to interact with passive animals"
         ClaimPermission.Detonate -> "Grants permission to directly set off explosives"
+        ClaimPermission.EventStart -> "Grants permission to start events such as raids and trials from an omen status effect"
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/utils/PermissionDisplay.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/utils/PermissionDisplay.kt
@@ -44,7 +44,7 @@ fun ClaimPermission.getDisplayName(): String {
         ClaimPermission.VillagerTrade -> "Trade Villagers"
         ClaimPermission.Husbandry -> "Husbandry"
         ClaimPermission.Detonate -> "Detonate"
-        ClaimPermission.EventStart -> "Omen"
+        ClaimPermission.EventStart -> "Raid"
     }
 }
 
@@ -65,6 +65,6 @@ fun ClaimPermission.getDescription(): String {
         ClaimPermission.VillagerTrade -> "Grants permission to trade with villagers"
         ClaimPermission.Husbandry -> "Grants permission to interact with passive animals"
         ClaimPermission.Detonate -> "Grants permission to directly set off explosives"
-        ClaimPermission.EventStart -> "Grants permission to start events such as raids and trials from an omen status effect"
+        ClaimPermission.EventStart -> "Grants permission to start a raid event"
     }
 }


### PR DESCRIPTION
Players can grief claims by going in with a bad omen effect to get their villagers killed. This stops it dead in its tracks, but it does also remove the effect entirely. Might come up with a solution for this later if possible.