### PR TITLE
Fixed GUI interaction errors in MC 1.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [Latest]
+
+### Added
+- Protection against players triggering a raid through a bad omen effect. Requires the new raid permission.
+
+## [0.2.3]
+Update to support MC version 1.21.1
+
+### Fixed
+- Inventory interactions not working in latest 1.21.1 version of MC.
+
 ## [0.2.2]
 
 ### Fixed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "dev.mizarc"
-version = "0.2.2"
+version = "0.2.3"
 
 repositories {
     mavenCentral()
@@ -38,7 +38,7 @@ dependencies {
     implementation("com.zaxxer:HikariCP:5.1.0")
     implementation("co.aikar:acf-paper:0.5.1-SNAPSHOT")
     implementation("co.aikar:idb-core:1.0.0-SNAPSHOT")
-    implementation("com.github.stefvanschie.inventoryframework:IF:0.10.15")
+    implementation("com.github.stefvanschie.inventoryframework:IF:0.10.17")
     compileOnly("com.github.MilkBowl:VaultAPI:1.7")
 }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: BellClaims
-version: 0.2.2
+version: 0.2.3
 api-version: '1.21'
 main: dev.mizarc.bellclaims.BellClaims
 softdepend: [Vault]


### PR DESCRIPTION
Due to changes in MC 1.21.1, the GUIs stopped working entirely preventing you from doing pretty much anything. All this needed to fix was an update to the Inventory Framework dependency to version 1.10.17.