### PR TITLE
Added flag protection against fluid flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Added
 - Protection against players triggering a raid through a bad omen effect. Requires the new raid permission.
+- Protection against fluid flow griefing, with players able to place fluids outside of the claim and having it flow into a claim. Bypassed by the fluid flow flag.
 
 ## [0.2.2]
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "dev.mizarc"
-version = "0.2.2"
+version = "0.3.0"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
@@ -47,6 +47,13 @@ enum class Flag(val rules: Array<RuleExecutor>) {
     Pistons(arrayOf(
         RuleBehaviour.pistonExtend,
         RuleBehaviour.pistonRetract
+    )),
+
+    /**
+     * When fluids flow into a claim
+     */
+    Fluids(arrayOf(
+        RuleBehaviour.fluidFlow
     ));
 
     companion object {

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
@@ -1,7 +1,7 @@
 package dev.mizarc.bellclaims.domain.flags
 
-import dev.mizarc.bellclaims.interaction.listeners.RuleBehaviour
-import dev.mizarc.bellclaims.interaction.listeners.RuleExecutor
+import dev.mizarc.bellclaims.interaction.behaviours.RuleBehaviour
+import dev.mizarc.bellclaims.interaction.behaviours.RuleExecutor
 import org.bukkit.event.Event
 
 /**

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
@@ -1,7 +1,7 @@
 package dev.mizarc.bellclaims.domain.permissions
 
-import dev.mizarc.bellclaims.interaction.listeners.PermissionBehaviour
-import dev.mizarc.bellclaims.interaction.listeners.PermissionExecutor
+import dev.mizarc.bellclaims.interaction.behaviours.PermissionBehaviour
+import dev.mizarc.bellclaims.interaction.behaviours.PermissionExecutor
 import org.bukkit.event.Event
 
 /**

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -1,4 +1,4 @@
-package dev.mizarc.bellclaims.interaction.listeners
+package dev.mizarc.bellclaims.interaction.behaviours
 
 import org.bukkit.Material
 import org.bukkit.World

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/PermissionBehaviour.kt
@@ -1,11 +1,10 @@
-package dev.mizarc.bellclaims.interaction.listeners
+package dev.mizarc.bellclaims.interaction.behaviours
 
 import io.papermc.paper.event.block.PlayerShearBlockEvent
 import io.papermc.paper.event.player.PlayerFlowerPotManipulateEvent
 import io.papermc.paper.event.player.PlayerOpenSignEvent
 import org.bukkit.Location
 import org.bukkit.Material
-import org.bukkit.World
 import org.bukkit.World.Environment
 import org.bukkit.block.data.AnaloguePowerable
 import org.bukkit.block.data.Openable
@@ -24,7 +23,6 @@ import org.bukkit.event.block.*
 import org.bukkit.event.entity.EntityDamageByEntityEvent
 import org.bukkit.event.entity.EntityPlaceEvent
 import org.bukkit.event.entity.ProjectileHitEvent
-import org.bukkit.event.entity.TrialSpawnerSpawnEvent
 import org.bukkit.event.hanging.HangingBreakByEntityEvent
 import org.bukkit.event.inventory.InventoryOpenEvent
 import org.bukkit.event.inventory.InventoryType

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/FlagBehaviour.kt
@@ -384,12 +384,19 @@ class RuleBehaviour {
 
         private fun cancelFluidFlow(event: Event, claimService: ClaimService,
                                     partitionService: PartitionService, flagService: FlagService): Boolean {
+            if (event !is BlockFromToEvent) return false
+            if (partitionService.getByLocation(event.block.location) != null) return false
+            if (partitionService.getByLocation(event.toBlock.location) == null) return false
+            event.isCancelled = true
             return true
         }
 
         private fun fluidFlowSourceInClaim(event: Event, claimService: ClaimService,
                                            partitionService: PartitionService): List<Claim> {
-
+            if (event !is BlockFromToEvent) return listOf()
+            val partition = partitionService.getByLocation(event.toBlock.location) ?: return listOf()
+            val claim = claimService.getById(partition.claimId) ?: return listOf()
+            return listOf(claim).distinct()
         }
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/FlagBehaviour.kt
@@ -73,6 +73,7 @@ class RuleBehaviour {
             Companion::cancelEntityExplosionHangingDamage, Companion::hangingBreakByEntityInClaim)
         val blockExplodeHangingDamage = RuleExecutor(HangingBreakEvent::class.java,
             Companion::cancelBlockExplosionHangingDamage, Companion::hangingBreakByBlockInClaim)
+        val fluidFlow = RuleExecutor(BlockFromToEvent::class.java, Companion::cancelFluidFlow, Companion::fluidFlowSourceInClaim)
 
         /**
          * Cancel any cancellable event.
@@ -379,6 +380,16 @@ class RuleBehaviour {
                 claimList.add(claim)
             }
             return claimList.distinct()
+        }
+
+        private fun cancelFluidFlow(event: Event, claimService: ClaimService,
+                                    partitionService: PartitionService, flagService: FlagService): Boolean {
+            return true
+        }
+
+        private fun fluidFlowSourceInClaim(event: Event, claimService: ClaimService,
+                                           partitionService: PartitionService): List<Claim> {
+
         }
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/utils/ClaimFlagDisplay.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/utils/ClaimFlagDisplay.kt
@@ -45,6 +45,6 @@ fun Flag.getDescription(): String {
         Flag.FireSpread -> "Allows fire to spread to other blocks"
         Flag.MobGriefing -> "Allows mobs to damage claim blocks"
         Flag.Pistons -> "Allows pistons to move claim blocks"
-        Flag.Fluids -> "Allows fluids to flow into claim blocks"
+        Flag.Fluids -> "Allows fluids to flow into the claim"
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/utils/ClaimFlagDisplay.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/utils/ClaimFlagDisplay.kt
@@ -32,7 +32,6 @@ fun Flag.getDisplayName(): String {
         Flag.Pistons -> "Pistons"
         Flag.Fluids -> "Fluid Flow"
     }
-    }
 }
 
 /**

--- a/src/main/kotlin/dev/mizarc/bellclaims/utils/ClaimFlagDisplay.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/utils/ClaimFlagDisplay.kt
@@ -15,6 +15,7 @@ fun Flag.getIcon(): ItemStack {
         Flag.FireSpread -> ItemStack(Material.FLINT_AND_STEEL)
         Flag.MobGriefing -> ItemStack(Material.CREEPER_HEAD)
         Flag.Pistons -> ItemStack(Material.PISTON)
+        Flag.Fluids -> ItemStack(Material.WATER_BUCKET)
     }
 }
 
@@ -29,6 +30,8 @@ fun Flag.getDisplayName(): String {
         Flag.FireSpread -> "Fire Spread"
         Flag.MobGriefing -> "Mob Griefing"
         Flag.Pistons -> "Pistons"
+        Flag.Fluids -> "Fluid Flow"
+    }
     }
 }
 
@@ -43,5 +46,6 @@ fun Flag.getDescription(): String {
         Flag.FireSpread -> "Allows fire to spread to other blocks"
         Flag.MobGriefing -> "Allows mobs to damage claim blocks"
         Flag.Pistons -> "Allows pistons to move claim blocks"
+        Flag.Fluids -> "Allows fluids to flow into claim blocks"
     }
 }


### PR DESCRIPTION
Water and Lava are ways that people can use to grief, as fluids that are placed outside of a claim can flow inside of a claim. This flag enables and disables this functionality to give players the choice to use this protection or not.