### PR TITLE
Changed piston flag behaviour to only cancel pistons used from outside the claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Protection against players triggering a raid through a bad omen effect. Requires the new raid permission.
 - Protection against fluid flow griefing, with players able to place fluids outside of the claim and having it flow into a claim. Bypassed by the fluid flow flag.
 
+### Changed
+- Piston protection now only applies if piston is outside of a claim moving blocks inside a claim.
+
 ## [0.2.2]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Protection against fluid flow griefing, with players able to place fluids outside of the claim and having it flow into a claim. Bypassed by the fluid flow flag.
 
 ### Changed
-- Piston protection now only applies if piston is outside of a claim moving blocks inside a claim.
+- Piston protection now only applies if the piston affecting the claim blocks is outside of the claim.
 
 ## [0.2.2]
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -403,13 +403,25 @@ class RuleBehaviour {
                                         partitionService: PartitionService, flagService: FlagService): Boolean {
             if (event !is BlockPistonRetractEvent) return false
             if (partitionService.getByLocation(event.block.location) != null) return false
+            var blockInClaim = false
+            for (block in event.blocks) {
+                if (partitionService.getByLocation(block.location) != null) blockInClaim = true
+            }
+            if (!blockInClaim) return false
+            event.isCancelled = true
             return true
         }
 
         private fun cancelPistonExtend(event: Event, claimService: ClaimService,
                                         partitionService: PartitionService, flagService: FlagService): Boolean {
-            if (event !is BlockPistonRetractEvent) return false
+            if (event !is BlockPistonExtendEvent) return false
             if (partitionService.getByLocation(event.block.location) != null) return false
+            var blockInClaim = false
+            for (block in event.blocks) {
+                if (partitionService.getByLocation(block.location) != null) blockInClaim = true
+            }
+            if (!blockInClaim) return false
+            event.isCancelled = true
             return true
         }
     }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -25,6 +25,7 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent
 import org.bukkit.event.entity.EntityDamageEvent
 import org.bukkit.event.hanging.HangingBreakByEntityEvent
 import org.bukkit.event.hanging.HangingBreakEvent
+import org.bukkit.util.Vector
 
 /**
  * A data structure that contains the type of event [eventClass], the function to handle the result of the event
@@ -416,10 +417,15 @@ class RuleBehaviour {
                                         partitionService: PartitionService, flagService: FlagService): Boolean {
             if (event !is BlockPistonExtendEvent) return false
             if (partitionService.getByLocation(event.block.location) != null) return false
+            val direction = event.direction.direction
             var blockInClaim = false
             for (block in event.blocks) {
-                if (partitionService.getByLocation(block.location) != null) blockInClaim = true
+                val newBlockPosition = block.location.clone()
+                newBlockPosition.add(direction)
+                if (partitionService.getByLocation(block.location) != null ||
+                    partitionService.getByLocation(newBlockPosition) != null) blockInClaim = true
             }
+
             if (!blockInClaim) return false
             event.isCancelled = true
             return true

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -58,9 +58,9 @@ class RuleBehaviour {
         val creeperDamageHangingEntity = RuleExecutor(HangingBreakByEntityEvent::class.java,
             Companion::cancelCreeperHangingDamage, Companion::hangingBreakByEntityInClaim)
         val pistonExtend = RuleExecutor(BlockPistonExtendEvent::class.java,
-            Companion::cancelEvent, Companion::pistonExtendInClaim)
+            Companion::cancelPistonExtend, Companion::pistonExtendInClaim)
         val pistonRetract = RuleExecutor(BlockPistonRetractEvent::class.java,
-            Companion::cancelEvent, Companion::pistonRetractInClaim)
+            Companion::cancelPistonRetract, Companion::pistonRetractInClaim)
         val entityExplode = RuleExecutor(EntityExplodeEvent::class.java,
             Companion::preventExplosionDamage, Companion::entityExplosionInClaim)
         val blockExplode = RuleExecutor(BlockExplodeEvent::class.java,
@@ -397,6 +397,20 @@ class RuleBehaviour {
             val partition = partitionService.getByLocation(event.toBlock.location) ?: return listOf()
             val claim = claimService.getById(partition.claimId) ?: return listOf()
             return listOf(claim).distinct()
+        }
+
+        private fun cancelPistonRetract(event: Event, claimService: ClaimService,
+                                        partitionService: PartitionService, flagService: FlagService): Boolean {
+            if (event !is BlockPistonRetractEvent) return false
+            if (partitionService.getByLocation(event.block.location) != null) return false
+            return true
+        }
+
+        private fun cancelPistonExtend(event: Event, claimService: ClaimService,
+                                        partitionService: PartitionService, flagService: FlagService): Boolean {
+            if (event !is BlockPistonRetractEvent) return false
+            if (partitionService.getByLocation(event.block.location) != null) return false
+            return true
         }
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/utils/ClaimFlagDisplay.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/utils/ClaimFlagDisplay.kt
@@ -44,7 +44,7 @@ fun Flag.getDescription(): String {
         Flag.Explosions -> "Allows TNT to damage claim blocks"
         Flag.FireSpread -> "Allows fire to spread to other blocks"
         Flag.MobGriefing -> "Allows mobs to damage claim blocks"
-        Flag.Pistons -> "Allows pistons to move claim blocks"
+        Flag.Pistons -> "Allows pistons placed outside the claim to move claim blocks"
         Flag.Fluids -> "Allows fluids to flow into the claim"
     }
 }


### PR DESCRIPTION
Rather than blocking all piston functionality inside the claim, this new system checks to see if the piston that is affecting the claim block is outside of the claim. This includes all blocks moved as well as the piston head itself.