### PR TITLE
Fixed bypassing protections when placing fluids by clicking through entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
-## [Latest]
+## [0.2.4]
 
-### Added
-- Protection against players triggering a raid through a bad omen effect. Requires the new raid permission.
+### Fixed
+- Placing bucket fluids by clicking through entities bypassing claim protections.
 
 ## [0.2.3]
 Update to support MC version 1.21.1

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
@@ -5,7 +5,6 @@ import io.papermc.paper.event.player.PlayerFlowerPotManipulateEvent
 import io.papermc.paper.event.player.PlayerOpenSignEvent
 import org.bukkit.Location
 import org.bukkit.Material
-import org.bukkit.World
 import org.bukkit.World.Environment
 import org.bukkit.block.data.AnaloguePowerable
 import org.bukkit.block.data.Openable
@@ -59,7 +58,7 @@ class PermissionBehaviour {
         val specialEntityDamage = PermissionExecutor(EntityDamageByEntityEvent::class.java, Companion::cancelSpecialEntityEvent, Companion::getEntityDamageByEntityLocation, Companion::getEntityDamageSourcePlayer)
 
         // Used for placing fluids such as water and lava
-        val fluidPlace = PermissionExecutor(PlayerInteractEvent::class.java, Companion::cancelFluidPlace, Companion::getInteractEventLocation, Companion::getInteractEventPlayer)
+        val fluidPlace = PermissionExecutor(PlayerBucketEmptyEvent::class.java, Companion::cancelEvent, Companion::getBucketLocation, Companion::getBucketPlayer)
 
         // Used for placing fluids such as water and lava
         val farmlandStep = PermissionExecutor(PlayerInteractEvent::class.java, Companion::cancelFarmlandStep, Companion::getInteractEventLocation, Companion::getInteractEventPlayer)
@@ -256,21 +255,6 @@ class PermissionBehaviour {
                 block.type != Material.LAVA_CAULDRON &&
                 block.type != Material.POWDER_SNOW_CAULDRON &&
                 block.type != Material.CAKE) return false
-            event.isCancelled = true
-            return true
-        }
-
-        /**
-         * Cancels the action of placing water or lava buckets.
-         */
-        private fun cancelFluidPlace(listener: Listener, event: Event): Boolean {
-            if (event !is PlayerInteractEvent) return false
-            if (event.action != Action.RIGHT_CLICK_BLOCK) return false
-            val clickedBlock = event.clickedBlock ?: return false
-            if (clickedBlock.type == Material.CAULDRON) return false
-            val item = event.item ?: return false
-            if (item.type != Material.WATER_BUCKET &&
-                item.type != Material.LAVA_BUCKET) return false
             event.isCancelled = true
             return true
         }
@@ -767,6 +751,16 @@ class PermissionBehaviour {
                 return event.entity.shooter as Player
             }
             return null
+        }
+
+        private fun getBucketLocation(event: Event): Location? {
+            if (event !is PlayerBucketEvent) return null
+            return event.block.location
+        }
+
+        private fun getBucketPlayer(event: Event): Player? {
+            if (event !is PlayerBucketEvent) return null
+            return event.player
         }
     }
 }


### PR DESCRIPTION
Due to the use of the generic player interaction event to block bucket fluid place usage, it only covered the use of placing fluids directly on blocks. Players were able to bypass this by clicking through an entity, which doesn't count as placing on a block but still takes into account the cursor position to place the fluid.