### PR TITLE
Added protection against placing paintings in claims

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,8 +2,8 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/BellClaims.Bell_Claims.main.iml" filepath="$PROJECT_DIR$/.idea/modules/BellClaims.Bell_Claims.main.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/BellClaims.Bell_Claims.test.iml" filepath="$PROJECT_DIR$/.idea/modules/BellClaims.Bell_Claims.test.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/BellClaims.main.iml" filepath="$PROJECT_DIR$/.idea/modules/BellClaims.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/BellClaims.test.iml" filepath="$PROJECT_DIR$/.idea/modules/BellClaims.test.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/Bell_Claims.main.iml" filepath="$PROJECT_DIR$/.idea/modules/Bell_Claims.main.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/Bell_Claims.test.iml" filepath="$PROJECT_DIR$/.idea/modules/Bell_Claims.test.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/bell-claims.Bell_Claims.main.iml" filepath="$PROJECT_DIR$/.idea/modules/bell-claims.Bell_Claims.main.iml" />

--- a/.idea/modules/BellClaims.main.iml
+++ b/.idea/modules/BellClaims.main.iml
@@ -6,6 +6,7 @@
         <autoDetectTypes>
           <platformType>PAPER</platformType>
           <platformType>ADVENTURE</platformType>
+          <platformType>BUKKIT</platformType>
         </autoDetectTypes>
         <projectReimportVersion>1</projectReimportVersion>
       </configuration>

--- a/.idea/modules/BellClaims.test.iml
+++ b/.idea/modules/BellClaims.test.iml
@@ -6,6 +6,7 @@
         <autoDetectTypes>
           <platformType>PAPER</platformType>
           <platformType>ADVENTURE</platformType>
+          <platformType>BUKKIT</platformType>
         </autoDetectTypes>
         <projectReimportVersion>1</projectReimportVersion>
       </configuration>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [0.2.4]
 
+### Added
+- Protection against painting placement. Requires the build permission.
+
 ### Fixed
 - Placing bucket fluids by clicking through entities bypassing claim protections.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "dev.mizarc"
-version = "0.2.3"
+version = "0.2.4"
 
 repositories {
     mavenCentral()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,1 @@
-rootProject.name = "Bell Claims"
+rootProject.name = "BellClaims"

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
@@ -19,6 +19,7 @@ enum class ClaimPermission(val parent: ClaimPermission?, val events: Array<Permi
         PermissionBehaviour.specialEntityDamage,
         PermissionBehaviour.fluidPlace,
         PermissionBehaviour.itemFramePlace,
+        PermissionBehaviour.paintingPlace,
         PermissionBehaviour.hangingEntityBreak,
         PermissionBehaviour.fertilize,
         PermissionBehaviour.farmlandStep,

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PermissionBehaviour.kt
@@ -66,6 +66,9 @@ class PermissionBehaviour {
         // Used for placing item frames
         val itemFramePlace = PermissionExecutor(PlayerInteractEvent::class.java, Companion::cancelItemFramePlace, Companion::getInteractEventLocation, Companion::getInteractEventPlayer)
 
+        // Used for placing paintings
+        val paintingPlace = PermissionExecutor(PlayerInteractEvent::class.java, Companion::cancelPaintingPlace, Companion::getInteractEventLocation, Companion::getInteractEventPlayer)
+
         // Used for breaking item frames and paintings
         val hangingEntityBreak = PermissionExecutor(HangingBreakByEntityEvent::class.java, Companion::cancelEvent, Companion::getHangingBreakByEntityEventLocation, Companion::getHangingBreakByEntityEventPlayer)
 
@@ -267,6 +270,18 @@ class PermissionBehaviour {
             if (event.action != Action.RIGHT_CLICK_BLOCK) return false
             val item = event.item ?: return false
             if (item.type != Material.ITEM_FRAME && item.type != Material.GLOW_ITEM_FRAME) return false
+            event.isCancelled = true
+            return true
+        }
+
+        /**
+         * Cancels the action of placing down paintings.
+         */
+        private fun cancelPaintingPlace(listener: Listener, event: Event): Boolean {
+            if (event !is PlayerInteractEvent) return false
+            if (event.action != Action.RIGHT_CLICK_BLOCK) return false
+            val item = event.item ?: return false
+            if (item.type != Material.PAINTING) return false
             event.isCancelled = true
             return true
         }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: BellClaims
-version: 0.2.3
+version: 0.2.4
 api-version: '1.21'
 main: dev.mizarc.bellclaims.BellClaims
 softdepend: [Vault]


### PR DESCRIPTION
Thought this was a bug at first, then realised I never even implemented it in the first place. This uses the same system as preventing players from placing item frames, but applied to paintings