### PR TITLE
Tweaked minimum partition size to 3x3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ### Added
 - Protection against painting placement. Requires the build permission.
 
+### Changed
+- Minimum partition size is now 3x3 down from "5x5", which was actually 7x7 due to it not counting the border.
+
 ### Fixed
 - Placing bucket fluids by clicking through entities bypassing claim protections.
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/PartitionServiceImpl.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/PartitionServiceImpl.kt
@@ -3,7 +3,6 @@ package dev.mizarc.bellclaims.infrastructure.services
 import dev.mizarc.bellclaims.api.ClaimService
 import dev.mizarc.bellclaims.api.PartitionService
 import dev.mizarc.bellclaims.api.PlayerLimitService
-import dev.mizarc.bellclaims.api.PlayerStateService
 import dev.mizarc.bellclaims.api.enums.PartitionCreationResult
 import dev.mizarc.bellclaims.api.enums.PartitionDestroyResult
 import dev.mizarc.bellclaims.api.enums.PartitionResizeResult
@@ -11,7 +10,6 @@ import org.bukkit.Location
 import dev.mizarc.bellclaims.domain.claims.Claim
 import dev.mizarc.bellclaims.domain.partitions.*
 import dev.mizarc.bellclaims.infrastructure.persistence.Config
-import org.bukkit.Bukkit
 import org.bukkit.Chunk
 import org.bukkit.World
 import java.util.*
@@ -83,7 +81,7 @@ class PartitionServiceImpl(private val config: Config,
         if (isPartitionTooClose(partition)) return PartitionCreationResult.TOO_CLOSE
 
         // Check if claim meets minimum size
-        if (area.getXLength() < 5 || area.getZLength() < 5) return PartitionCreationResult.TOO_SMALL
+        if (area.getXLength() < 1 || area.getZLength() < 1) return PartitionCreationResult.TOO_SMALL
 
         // Check if selection is greater than the player's remaining claim blocks
         val remainingClaimBlockCount = playerLimitService.getRemainingClaimBlockCount(claim.owner)
@@ -128,7 +126,7 @@ class PartitionServiceImpl(private val config: Config,
             return PartitionResizeResult.EXPOSED_CLAIM_HUB
 
         // Check if claim meets minimum size
-        if (newPartition.area.getXLength() < 5 || newPartition.area.getZLength() < 5)
+        if (newPartition.area.getXLength() < 1 || newPartition.area.getZLength() < 1)
             return PartitionResizeResult.TOO_SMALL
 
         // Check if claim takes too much space

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolListener.kt
@@ -165,7 +165,7 @@ class EditToolListener(private val claims: ClaimRepository,
                 return player.sendActionBar(Component.text("That selection is too close to another claim")
                     .color(TextColor.color(255, 85, 85)))
             PartitionCreationResult.TOO_SMALL ->
-                return player.sendActionBar(Component.text("The claim must be at least 5x5 blocks")
+                return player.sendActionBar(Component.text("The claim must be at least 3x3 blocks")
                     .color(TextColor.color(255, 85, 85)))
             PartitionCreationResult.INSUFFICIENT_BLOCKS ->
                 return player.sendActionBar(Component.text("That selection would require an additional " +
@@ -246,7 +246,7 @@ class EditToolListener(private val claims: ClaimRepository,
                         "being outside the claim area")
                     .color(TextColor.color(255, 85, 85)))
             PartitionResizeResult.TOO_SMALL ->
-                player.sendActionBar(Component.text("The claim must be at least 5x5 blocks")
+                player.sendActionBar(Component.text("The claim must be at least 3x3 blocks")
                     .color(TextColor.color(255, 85, 85)))
             PartitionResizeResult.DISCONNECTED ->
                 player.sendActionBar(Component.text("Resizing to that size would result in a gap between " +


### PR DESCRIPTION
The previous size was supposed to be 5x5, but turned out to be 7x7 due to it not counting the claim border itself. The maths behind this still needs to be tweaked, and will be configurable in the future. For now the new absolute minimum will be 3x3.