### PR TITLE
Fixed the creation of 1 block wide partitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [0.2.5]
+
+### Fixed
+- Creation of 1 block wide partitions due to funky math error that only applied when the minimum limit was set to 3x3.
+
 ## [0.2.4]
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "dev.mizarc"
-version = "0.2.4"
+version = "0.2.5"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/partitions/Area.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/partitions/Area.kt
@@ -136,14 +136,14 @@ data class Area(var lowerPosition2D: Position2D, var upperPosition2D: Position2D
      * @return The
      */
     fun getXLength(): Int {
-        return (lowerPosition2D.x - upperPosition2D.x + 1).absoluteValue
+        return (upperPosition2D.x - lowerPosition2D.x).absoluteValue
     }
 
     /**
      * Gets the length of the Z axis
      */
     fun getZLength(): Int {
-        return (lowerPosition2D.z - upperPosition2D.z + 1).absoluteValue
+        return (upperPosition2D.z - lowerPosition2D.z).absoluteValue
     }
 
     fun getCornerBlockPositions(): ArrayList<Position2D> {

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/partitions/Area.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/partitions/Area.kt
@@ -36,7 +36,7 @@ data class Area(var lowerPosition2D: Position2D, var upperPosition2D: Position2D
     /**
      * Checks if the specified position exists within the bounds of this area.
      *
-     * @param position2D The position to check
+     * @param position The position to check
      * @return True if in area.
      */
     fun isPositionInArea(position: Position): Boolean {
@@ -136,14 +136,14 @@ data class Area(var lowerPosition2D: Position2D, var upperPosition2D: Position2D
      * @return The
      */
     fun getXLength(): Int {
-        return (upperPosition2D.x - lowerPosition2D.x).absoluteValue
+        return (upperPosition2D.x - lowerPosition2D.x + 1).absoluteValue
     }
 
     /**
      * Gets the length of the Z axis
      */
     fun getZLength(): Int {
-        return (upperPosition2D.z - lowerPosition2D.z).absoluteValue
+        return (upperPosition2D.z - lowerPosition2D.z + 1).absoluteValue
     }
 
     fun getCornerBlockPositions(): ArrayList<Position2D> {

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/PartitionServiceImpl.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/PartitionServiceImpl.kt
@@ -81,7 +81,7 @@ class PartitionServiceImpl(private val config: Config,
         if (isPartitionTooClose(partition)) return PartitionCreationResult.TOO_CLOSE
 
         // Check if claim meets minimum size
-        if (area.getXLength() < 1 || area.getZLength() < 1) return PartitionCreationResult.TOO_SMALL
+        if (area.getXLength() < 3 || area.getZLength() < 3) return PartitionCreationResult.TOO_SMALL
 
         // Check if selection is greater than the player's remaining claim blocks
         val remainingClaimBlockCount = playerLimitService.getRemainingClaimBlockCount(claim.owner)
@@ -126,7 +126,7 @@ class PartitionServiceImpl(private val config: Config,
             return PartitionResizeResult.EXPOSED_CLAIM_HUB
 
         // Check if claim meets minimum size
-        if (newPartition.area.getXLength() < 1 || newPartition.area.getZLength() < 1)
+        if (newPartition.area.getXLength() < 3 || newPartition.area.getZLength() < 3)
             return PartitionResizeResult.TOO_SMALL
 
         // Check if claim takes too much space

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: BellClaims
-version: 0.2.4
+version: 0.2.5
 api-version: '1.21'
 main: dev.mizarc.bellclaims.BellClaims
 softdepend: [Vault]

--- a/src/test/kotlin/dev/mizarc/bellclaims/infrastructure/services/PartitionServiceImplTest.kt
+++ b/src/test/kotlin/dev/mizarc/bellclaims/infrastructure/services/PartitionServiceImplTest.kt
@@ -309,6 +309,9 @@ class PartitionServiceImplTest {
         every { partitionRepo.getByChunk(any()) } returns
                 setOf(partitionCollectionOne[0], partitionCollectionOne[1], partitionCollectionTwo[0])
         every { config.distanceBetweenClaims } returns 3
+        every { playerLimitService.getRemainingClaimBlockCount(playerOne) } returns 10000
+        every { partitionRepo.add(any()) } returns Unit
+
 
         // When
         val result = partitionService.append(area, claimOne)
@@ -442,6 +445,7 @@ class PartitionServiceImplTest {
         every { partitionRepo.getByPosition(Position2D(21, 30)) } returns setOf(partitionCollectionTwo[0])
         every { partitionRepo.getByChunk(any()) } returns (partitionCollectionOne + partitionCollectionTwo).toSet()
         every { config.distanceBetweenClaims } returns 3
+        every {playerLimitService.getRemainingClaimBlockCount(playerOne)} returns 10000
 
         // When
         val result = partitionService.resize(partitionCollectionTwo[1], area)


### PR DESCRIPTION
This should not be possible at all, but only presented itself as a problem once the claim limit was set to 3x3. Doesn't happen with any other larger limit, but it exposed a fatal math flaw in the area calculations.

As a result, this broke visualisations as well as the partition itself, having to resolve it by removing the partition.