### PR TITLE
Disable skeleton griefing Item Frames / Paitings

### DIFF
--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
@@ -25,8 +25,8 @@ enum class Flag(val rules: Array<RuleExecutor>) {
     MobGriefing(arrayOf(
         RuleBehaviour.mobBlockChange,
         RuleBehaviour.mobBreakDoor,
-        RuleBehaviour.skeletonHangingDamage,
-        RuleBehaviour.skeletonDamageStaticEntity,
+        RuleBehaviour.mobHangingDamage,
+        RuleBehaviour.mobDamageStaticEntity,
         RuleBehaviour.creeperExplode,
         RuleBehaviour.creeperDamageStaticEntity,
         RuleBehaviour.creeperDamageHangingEntity

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
@@ -3,6 +3,7 @@ package dev.mizarc.bellclaims.domain.flags
 import dev.mizarc.bellclaims.interaction.behaviours.RuleBehaviour
 import dev.mizarc.bellclaims.interaction.behaviours.RuleExecutor
 import org.bukkit.event.Event
+import org.junit.Rule
 
 /**
  * Represents the expected behaviour of certain events in claims that do not pertain to players.
@@ -24,6 +25,8 @@ enum class Flag(val rules: Array<RuleExecutor>) {
     MobGriefing(arrayOf(
         RuleBehaviour.mobBlockChange,
         RuleBehaviour.mobBreakDoor,
+        RuleBehaviour.skeletonHangingDamage,
+        RuleBehaviour.skeletonDamageStaticEntity,
         RuleBehaviour.creeperExplode,
         RuleBehaviour.creeperDamageStaticEntity,
         RuleBehaviour.creeperDamageHangingEntity

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -14,14 +14,7 @@ import dev.mizarc.bellclaims.api.FlagService
 import dev.mizarc.bellclaims.api.PartitionService
 import dev.mizarc.bellclaims.domain.claims.Claim
 import dev.mizarc.bellclaims.domain.flags.Flag
-import org.bukkit.entity.ArmorStand
-import org.bukkit.entity.Arrow
-import org.bukkit.entity.Creeper
-import org.bukkit.entity.ItemFrame
-import org.bukkit.entity.Monster
-import org.bukkit.entity.Painting
-import org.bukkit.entity.Projectile
-import org.bukkit.entity.Skeleton
+import org.bukkit.entity.*
 import org.bukkit.event.entity.EntityBreakDoorEvent
 import org.bukkit.event.entity.EntityDamageByBlockEvent
 import org.bukkit.event.entity.EntityDamageByEntityEvent
@@ -55,10 +48,10 @@ class RuleBehaviour {
             Companion::cancelEntityBlockChange, Companion::entityGriefInClaim)
         val mobBreakDoor = RuleExecutor(EntityBreakDoorEvent::class.java,
             Companion::cancelEntityBreakDoor, Companion::entityBreakDoorInClaim)
-        val skeletonDamageStaticEntity = RuleExecutor(EntityDamageByEntityEvent::class.java,
-            Companion::cancelSkeletonArrowDamage, Companion::entityDamageInClaim)
-        val skeletonHangingDamage = RuleExecutor(HangingBreakByEntityEvent::class.java,
-            Companion::cancelSkeletonArrowHangingDamage, Companion::hangingBreakByEntityInClaim)
+        val mobDamageStaticEntity = RuleExecutor(EntityDamageByEntityEvent::class.java,
+            Companion::cancelMobEntityDamage, Companion::entityDamageInClaim)
+        val mobHangingDamage = RuleExecutor(HangingBreakByEntityEvent::class.java,
+            Companion::cancelMobHangingDamage, Companion::hangingBreakByEntityInClaim)
         val creeperExplode = RuleExecutor(EntityExplodeEvent::class.java,
             Companion::cancelCreeperExplode, Companion::entityExplosionInClaim)
         val creeperDamageStaticEntity = RuleExecutor(EntityDamageByEntityEvent::class.java,
@@ -95,11 +88,11 @@ class RuleBehaviour {
             return false
         }
 
-        private fun cancelSkeletonArrowHangingDamage(event: Event, claimService: ClaimService,
+        private fun cancelMobHangingDamage(event: Event, claimService: ClaimService,
                                                        partitionService: PartitionService,
                                                        flagService: FlagService): Boolean {
             if (event !is HangingBreakByEntityEvent) return false
-            if (event.remover !is Skeleton) return false
+            if (event.remover !is Skeleton && event.remover !is Blaze) return false
             if (event.entity !is ItemFrame && event.entity !is Painting) return false
             event.isCancelled = true
             return true
@@ -229,10 +222,10 @@ class RuleBehaviour {
             return true
         }
 
-        private fun cancelSkeletonArrowDamage(event: Event, claimService: ClaimService,
+        private fun cancelMobEntityDamage(event: Event, claimService: ClaimService,
                                         partitionService: PartitionService, flagService: FlagService): Boolean {
             if (event !is EntityDamageByEntityEvent) return false
-            if (event.damager !is Arrow) return false
+            if (event.damager !is Arrow && event.damager !is Fireball) return false
             if (event.cause != EntityDamageEvent.DamageCause.PROJECTILE) return false
             event.isCancelled = true
             return true

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -96,7 +96,8 @@ class RuleBehaviour {
                 && event.remover !is Blaze
                 && event.remover !is Ghast
                 && event.remover !is Snowman
-                && event.remover !is Pillager) return false
+                && event.remover !is Pillager
+                && event.remover !is Wither) return false
             if (event.entity !is ItemFrame && event.entity !is Painting) return false
             event.isCancelled = true
             return true

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -78,7 +78,7 @@ class RuleBehaviour {
         val blockExplodeDamage = RuleExecutor(EntityDamageByBlockEvent::class.java,
             Companion::cancelBlockExplosionDamage, Companion::blockDamageInClaim)
         val entityExplodeHangingDamage = RuleExecutor(HangingBreakByEntityEvent::class.java,
-            Companion::cancelCreeperExplosionHangingDamage, Companion::hangingBreakByEntityInClaim)
+            Companion::cancelEntityExplosionHangingDamage, Companion::hangingBreakByEntityInClaim)
         val blockExplodeHangingDamage = RuleExecutor(HangingBreakEvent::class.java,
             Companion::cancelBlockExplosionHangingDamage, Companion::hangingBreakByBlockInClaim)
         val fluidFlow = RuleExecutor(BlockFromToEvent::class.java, Companion::cancelFluidFlow, Companion::fluidFlowSourceInClaim)
@@ -105,7 +105,7 @@ class RuleBehaviour {
             return true
         }
 
-        private fun cancelCreeperExplosionHangingDamage(event: Event, claimService: ClaimService,
+        private fun cancelEntityExplosionHangingDamage(event: Event, claimService: ClaimService,
                                                        partitionService: PartitionService,
                                                        flagService: FlagService): Boolean {
             if (event !is HangingBreakByEntityEvent) return false

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -92,7 +92,7 @@ class RuleBehaviour {
                                                        partitionService: PartitionService,
                                                        flagService: FlagService): Boolean {
             if (event !is HangingBreakByEntityEvent) return false
-            if (event.remover !is Skeleton && event.remover !is Blaze && event.remover !is Ghast) return false
+            if (event.remover !is Skeleton && event.remover !is Blaze && event.remover !is Ghast && event.remover !is Snowman) return false
             if (event.entity !is ItemFrame && event.entity !is Painting) return false
             event.isCancelled = true
             return true
@@ -225,7 +225,7 @@ class RuleBehaviour {
         private fun cancelMobEntityDamage(event: Event, claimService: ClaimService,
                                         partitionService: PartitionService, flagService: FlagService): Boolean {
             if (event !is EntityDamageByEntityEvent) return false
-            if (event.damager !is Arrow && event.damager !is Fireball) return false
+            if (event.damager !is Arrow && event.damager !is Fireball && event.damager !is Snowball) return false
             if (event.cause != EntityDamageEvent.DamageCause.PROJECTILE) return false
             event.isCancelled = true
             return true

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -92,7 +92,7 @@ class RuleBehaviour {
                                                        partitionService: PartitionService,
                                                        flagService: FlagService): Boolean {
             if (event !is HangingBreakByEntityEvent) return false
-            if (event.remover !is Skeleton && event.remover !is Blaze) return false
+            if (event.remover !is Skeleton && event.remover !is Blaze && event.remover !is Ghast) return false
             if (event.entity !is ItemFrame && event.entity !is Painting) return false
             event.isCancelled = true
             return true

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -92,7 +92,11 @@ class RuleBehaviour {
                                                        partitionService: PartitionService,
                                                        flagService: FlagService): Boolean {
             if (event !is HangingBreakByEntityEvent) return false
-            if (event.remover !is Skeleton && event.remover !is Blaze && event.remover !is Ghast && event.remover !is Snowman) return false
+            if (event.remover !is Skeleton
+                && event.remover !is Blaze
+                && event.remover !is Ghast
+                && event.remover !is Snowman
+                && event.remover !is Pillager) return false
             if (event.entity !is ItemFrame && event.entity !is Painting) return false
             event.isCancelled = true
             return true


### PR DESCRIPTION
This pull request solves the problem where skeletons could be used to grief users item frames and paintings inside a claim. An example of how this could be abused was putting a skeleton in boat, driving it to inside a claim and then making the skeleton shoot in the direction of the item frame / painting. This pull request makes this mechanic available under mob griefing.

Video will be send on discord to show the functionality of this hotfix.