### PR TITLE
Check horse passenger for permission

### DIFF
--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
@@ -23,6 +23,7 @@ enum class ClaimPermission(val parent: ClaimPermission?, val events: Array<Permi
         PermissionBehaviour.hangingEntityBreak,
         PermissionBehaviour.fertilize,
         PermissionBehaviour.farmlandStep,
+        PermissionBehaviour.mountFarmlandStep,
         PermissionBehaviour.dragonEggTeleport,
         PermissionBehaviour.bucketFill,
         PermissionBehaviour.pumpkinShear


### PR DESCRIPTION
Before this hotfix a user would be able to take a horse (Mountable entity) and jump on other peoples farmland to destory it. With this hotfix on an entity interact event there will be looked if that entity contains an passenger. If the entity does and the passenger is a player check for the players permission to build. If the player does not have permission the event will be cancelled otherwise it will contiue.