### PR TITLE
Protect passive mobs from direct hits by hostile mobs

### DIFF
--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -235,8 +235,8 @@ class RuleBehaviour {
         private fun cancelMobEntityDamage(event: Event, claimService: ClaimService,
                                         partitionService: PartitionService, flagService: FlagService): Boolean {
             if (event !is EntityDamageByEntityEvent) return false
-            if (event.damager !is Arrow && event.damager !is Fireball && event.damager !is Snowball) return false
-            if (event.cause != EntityDamageEvent.DamageCause.PROJECTILE) return false
+            if (event.damager !is Monster && event.damager !is Arrow &&
+                event.damager !is Fireball && event.damager !is Snowball) return false
             if (event.damageSource.causingEntity is Player) return false
             if (event.entity is Player) return false
             event.isCancelled = true

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -237,6 +237,8 @@ class RuleBehaviour {
             if (event !is EntityDamageByEntityEvent) return false
             if (event.damager !is Arrow && event.damager !is Fireball && event.damager !is Snowball) return false
             if (event.cause != EntityDamageEvent.DamageCause.PROJECTILE) return false
+            if (event.damageSource.causingEntity is Player) return false
+            if (event.entity is Player) return false
             event.isCancelled = true
             return true
         }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -238,7 +238,7 @@ class RuleBehaviour {
             if (event.damager !is Monster && event.damager !is Arrow &&
                 event.damager !is Fireball && event.damager !is Snowball) return false
             if (event.damageSource.causingEntity is Player) return false
-            if (event.entity is Player) return false
+            if (event.entity is Player || event.entity is Monster) return false
             event.isCancelled = true
             return true
         }


### PR DESCRIPTION
Any "Monster" class hostile mob is now unable to damage entities that are either the player, or other "Monster" class mob. This also collaterally solves the issue of #52 in the process.