### PR TITLE
Fixed shift right clicking deleting player's items in menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ### Fixed
 - Multi-blocks bypassing protections when the source is placed outside of the claim.
 - Protection event priority changed to "LOWEST" in order to override other plugins being able to bypass protections.
+- Shift + right clicking an item in the player's own inventory inside a menu moves it and becomes irretrievable.
 
 ## [0.2.5]
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/ClaimListMenu.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/ClaimListMenu.kt
@@ -20,7 +20,8 @@ class ClaimListMenu(private val claimService: ClaimService, private val player: 
         val claims = claimService.getByPlayer(player)
         val gui = ChestGui(6, "Claims")
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
-        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
+            guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
 
         // Add controls pane
         val controlsPane = StaticPane(0, 0, 9, 1)

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/ClaimManagementMenu.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/ClaimManagementMenu.kt
@@ -46,7 +46,8 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         val gui = ChestGui(1, "Claim Creation")
         val pane = StaticPane(0, 0, 9, 1)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
-        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
+            guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
         gui.addPane(pane)
 
         // Check if player doesn't have enough claims
@@ -87,7 +88,8 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         // Create homes menu
         val gui = AnvilGui("Naming Claim")
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
-        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
+            guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
 
         // Add lodestone menu item
         val firstPane = StaticPane(0, 0, 1, 1)
@@ -132,7 +134,8 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         val gui = ChestGui(1, "Claim '${claim.name}'")
         val pane = StaticPane(0, 0, 9, 1)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
-        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
+            guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
         gui.addPane(pane)
 
         // Add claim tool button
@@ -212,7 +215,8 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         val gui = FurnaceGui(getLangText("SetWarpIcon"))
         val fuelPane = StaticPane(0, 0, 1, 1)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
-        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
+            guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
 
         // Add info paper menu item
         val paperItem = ItemStack(Material.PAPER)
@@ -269,7 +273,8 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         // Create homes menu
         val gui = AnvilGui(getLangText("RenamingClaim"))
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
-        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
+            guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
 
         // Add lodestone menu item
         val firstPane = StaticPane(0, 0, 1, 1)
@@ -320,7 +325,8 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         // Create claim flags menu
         val gui = ChestGui(4, "Claim Flags")
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
-        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
+            guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
 
         // Add controls pane
         val controlsPane = StaticPane(0, 0, 9, 1)
@@ -427,7 +433,8 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         // Create trust menu
         val gui = ChestGui(6, "Trusted Players")
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
-        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
+            guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
 
         // Add controls pane
         val controlsPane = addControlsSection(gui) { openClaimEditMenu(claim) }
@@ -476,7 +483,8 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         // Create player permissions menu
         val gui = ChestGui(6, "${player.name}'s Permissions")
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
-        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
+            guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
 
         // Add controls pane
         val controlsPane = addControlsSection(gui) { openClaimTrustMenu(claim, 0) }
@@ -561,7 +569,8 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         // Create player permissions menu
         val gui = ChestGui(6, "Default Claim Permissions")
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
-        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
+            guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
 
         // Add controls
         val controlsPane = addControlsSection(gui) { openClaimTrustMenu(claim, 0) }
@@ -651,7 +660,8 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         // Create trust menu
         val gui = ChestGui(6, "All Players")
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
-        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
+            guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
 
         // Add controls
         val controlsPane = addControlsSection(gui) { openClaimTrustMenu(claim, 0) }
@@ -696,7 +706,8 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         // Create homes menu
         val gui = AnvilGui(getLangText("SearchForPlayer"))
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
-        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
+            guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
 
         // Add lodestone menu item
         val firstPane = StaticPane(0, 0, 1, 1)

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/EditToolMenu.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/EditToolMenu.kt
@@ -25,7 +25,8 @@ class EditToolMenu(private val claimService: ClaimService, private val partition
     fun openEditToolMenu() {
         val gui = ChestGui(1, getLangText("ClaimTool2"))
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
-        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
+            guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
 
         val pane = StaticPane(0, 0, 9, 1)
         gui.addPane(pane)
@@ -130,7 +131,8 @@ class EditToolMenu(private val claimService: ClaimService, private val partition
         val gui = HopperGui(getLangText("DeletePartitionQuestion"))
         val pane = StaticPane(1, 0, 3, 1)
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
-        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT) guiEvent.isCancelled = true }
+        gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
+            guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
         gui.slotsComponent.addPane(pane)
 
         // Add no menu item


### PR DESCRIPTION
This resolves the issue where if a player shift right clicks an item in their own inventory while inside of a menu, the item gets moved into the menu and cannot be retrieved. This effectively deletes the item.