### PR TITLE
Added new flag to handle dispenser protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Added
 - Protection against players triggering a raid through a bad omen effect. Requires the new raid permission.
-- Protection against fluid flow griefing, with players able to place fluids outside of the claim and having it flow into a claim. Bypassed by the fluid flow flag.
+- Protection against fluid flow griefing, with players able to place fluids outside of the claim and having it flow into a claim. Bypassed by the new fluid flow flag.
 - Individual flags to allow the claim owner to control the existing tree growth and sculk spread protections.
 - Protection against mobs breaking static entities such as item frames and paintings. Bypassed by the mob griefing flag.
 - Protection against trampling using rideable mobs. Requires the build permission.
+- Protection against dispensers placed on the outer edge of the claim being used to grief with fluids or entities such as boats and armor stands. Bypassed by the new dispense flag.
 - Language file support, with all known instances of display text moved to a language file resource.
 - English language complete.
 - Chinese language machine translated. (Temporary, for demonstration)

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
@@ -65,6 +65,10 @@ enum class Flag(val rules: Array<RuleExecutor>) {
 
     Sculk(arrayOf(
         RuleBehaviour.sculkSpread
+    )),
+
+    Dispensers(arrayOf(
+        RuleBehaviour.dispense
     ));
 
     companion object {

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -39,7 +39,7 @@ data class RuleExecutor(val eventClass: Class<out Event>,
  * rules that allow them to.
  */
 class RuleBehaviour {
-    @Suppress("UNUSED_PARAMETER")
+    @Suppress("unused")
     companion object {
         val fireBurn = RuleExecutor(BlockBurnEvent::class.java,
             Companion::cancelEvent, Companion::blockInClaim)

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -14,6 +14,7 @@ import dev.mizarc.bellclaims.api.FlagService
 import dev.mizarc.bellclaims.api.PartitionService
 import dev.mizarc.bellclaims.domain.claims.Claim
 import dev.mizarc.bellclaims.domain.flags.Flag
+import org.bukkit.block.data.Directional
 import org.bukkit.entity.*
 import org.bukkit.event.entity.EntityBreakDoorEvent
 import org.bukkit.event.entity.EntityDamageByBlockEvent
@@ -80,6 +81,8 @@ class RuleBehaviour {
             Companion::treeGrowthInClaim)
         val sculkSpread = RuleExecutor(BlockSpreadEvent::class.java, Companion::cancelSculkSpread,
             Companion::blockSpreadInClaim)
+        val dispense = RuleExecutor(BlockDispenseEvent::class.java, Companion::cancelBlockDispenseEvent,
+            Companion::blockDispenseInClaim)
 
         /**
          * Cancel any cancellable event.
@@ -543,6 +546,23 @@ class RuleBehaviour {
                                       partitionService: PartitionService, flagService: FlagService): Boolean {
             if (event !is BlockSpreadEvent) return false
             if (event.source.type != Material.FIRE) return false
+            event.isCancelled = true
+            return true
+        }
+
+        private fun blockDispenseInClaim(event: Event, claimService: ClaimService,
+                                         partitionService: PartitionService): List<Claim> {
+            if (event !is BlockDispenseEvent) return listOf()
+            val directionalBlock = event.block.blockData as Directional
+            val placeLocation = event.block.location.add(directionalBlock.facing.direction)
+            val partition = partitionService.getByLocation(placeLocation) ?: return listOf()
+            val claim = claimService.getById(partition.claimId) ?: return listOf()
+            return listOf(claim)
+        }
+
+        private fun cancelBlockDispenseEvent(event: Event, claimService: ClaimService,
+                                             partitionService: PartitionService, flagService: FlagService): Boolean {
+            if (event !is BlockDispenseEvent) return false
             event.isCancelled = true
             return true
         }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -81,7 +81,7 @@ class RuleBehaviour {
             Companion::treeGrowthInClaim)
         val sculkSpread = RuleExecutor(BlockSpreadEvent::class.java, Companion::cancelSculkSpread,
             Companion::blockSpreadInClaim)
-        val dispense = RuleExecutor(BlockDispenseEvent::class.java, Companion::cancelBlockDispenseEvent,
+        val dispense = RuleExecutor(BlockDispenseEvent::class.java, Companion::cancelEvent,
             Companion::blockDispenseInClaim)
 
         /**
@@ -558,13 +558,6 @@ class RuleBehaviour {
             val partition = partitionService.getByLocation(placeLocation) ?: return listOf()
             val claim = claimService.getById(partition.claimId) ?: return listOf()
             return listOf(claim)
-        }
-
-        private fun cancelBlockDispenseEvent(event: Event, claimService: ClaimService,
-                                             partitionService: PartitionService, flagService: FlagService): Boolean {
-            if (event !is BlockDispenseEvent) return false
-            event.isCancelled = true
-            return true
         }
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/ClaimManagementMenu.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/ClaimManagementMenu.kt
@@ -323,7 +323,7 @@ class ClaimManagementMenu(private val claimService: ClaimService,
 
     fun openClaimFlagMenu(claim: Claim) {
         // Create claim flags menu
-        val gui = ChestGui(4, "Claim Flags")
+        val gui = ChestGui(5, "Claim Flags")
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
             guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
@@ -368,7 +368,7 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         // Add vertical divider
         val verticalDividerPane = StaticPane(4, 2, 1, 6)
         gui.addPane(verticalDividerPane)
-        for (slot in 0..1) {
+        for (slot in 0..2) {
             verticalDividerPane.addItem(guiDividerItem, 0, slot)
         }
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/utils/ClaimFlagDisplay.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/utils/ClaimFlagDisplay.kt
@@ -20,6 +20,7 @@ fun Flag.getIcon(): ItemStack {
         Flag.Fluids -> ItemStack(Material.WATER_BUCKET)
         Flag.Trees -> ItemStack(Material.OAK_SAPLING)
         Flag.Sculk -> ItemStack(Material.SCULK_CATALYST)
+        Flag.Dispensers -> ItemStack(Material.DISPENSER)
     }
 }
 
@@ -37,6 +38,7 @@ fun Flag.getDisplayName(): String {
         Flag.Fluids -> getLangText("NameFlagFluids")
         Flag.Trees -> getLangText("NameFlagTrees")
         Flag.Sculk -> getLangText("NameFlagSculk")
+        Flag.Dispensers -> getLangText("NameFlagDispensers")
     }
 }
 
@@ -54,5 +56,6 @@ fun Flag.getDescription(): String {
         Flag.Fluids -> getLangText("DescFlagFluids")
         Flag.Trees -> getLangText("DescFlagTrees")
         Flag.Sculk -> getLangText("DescFlagSculk")
+        Flag.Dispensers -> getLangText("DescFlagDispensers")
     }
 }

--- a/src/main/resources/lang_EN.yml
+++ b/src/main/resources/lang_EN.yml
@@ -7,6 +7,7 @@ NameFlagPistons: "Pistons"
 NameFlagFluids: "Fluid Flow"
 NameFlagTrees: "Tree Growth"
 NameFlagSculk: "Sculk Spread"
+NameFlagDispenser: "Dispense"
 
 DescFlagExplosions: "Allows TNT to damage claim blocks"
 DescFlagFireSpread: "Allows fire to spread to other blocks"
@@ -15,6 +16,7 @@ DescFlagPistons: "Allows pistons placed outside the claim to move claim blocks"
 DescFlagFluids: "Allows fluids to flow into the claim"
 DescFlagTrees: "Allows trees planted outside to grow into the claim"
 DescFlagSculk: "Allows sculk catalysts placed outside to grow into the claim"
+DescFlagDispenser: "Allows dispensers placed outside to dispense into the claim"
 
 # --- PermissionDisplay.kt ---
 


### PR DESCRIPTION
This stops players from being able to use dispensers to dispense fluids, boats, and other entities such as armour stands into a claim. It allow affects general item dropping, but having a whitelist for specific items seems like too much of a hassle for very little gain.