### PR TITLE
Added protection against using sponge to drain claim fluids

### DIFF
--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
@@ -69,6 +69,10 @@ enum class Flag(val rules: Array<RuleExecutor>) {
 
     Dispensers(arrayOf(
         RuleBehaviour.dispense
+    )),
+
+    Sponge(arrayOf(
+        RuleBehaviour.spongeAbsorb
     ));
 
     companion object {

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -578,6 +578,7 @@ class RuleBehaviour {
         private fun cancelSpongeAbsorbEvent(event: Event, claimService: ClaimService,
                                      partitionService: PartitionService, flagService: FlagService): Boolean {
             if (event !is SpongeAbsorbEvent) return false
+            if (partitionService.getByLocation(event.block.location) != null) return false
             val cancelledBlocks: MutableList<BlockState> = mutableListOf()
             for (block in event.blocks) {
                 val partition = partitionService.getByLocation(block.location) ?: continue

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/ClaimManagementMenu.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/ClaimManagementMenu.kt
@@ -376,7 +376,7 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         val disabledRules = Flag.entries.toTypedArray().subtract(enabledRules)
 
         // Add list of disabled permissions
-        val disabledPermissionsPane = StaticPane(0, 2, 4, 2)
+        val disabledPermissionsPane = StaticPane(0, 2, 4, 3)
         gui.addPane(disabledPermissionsPane)
         var xSlot = 0
         var ySlot = 0
@@ -400,7 +400,7 @@ class ClaimManagementMenu(private val claimService: ClaimService,
             }
         }
 
-        val enabledPermissionsPane = StaticPane(5, 2, 4, 2)
+        val enabledPermissionsPane = StaticPane(5, 2, 4, 3)
         gui.addPane(enabledPermissionsPane)
         xSlot = 0
         ySlot = 0

--- a/src/main/kotlin/dev/mizarc/bellclaims/utils/ClaimFlagDisplay.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/utils/ClaimFlagDisplay.kt
@@ -21,6 +21,7 @@ fun Flag.getIcon(): ItemStack {
         Flag.Trees -> ItemStack(Material.OAK_SAPLING)
         Flag.Sculk -> ItemStack(Material.SCULK_CATALYST)
         Flag.Dispensers -> ItemStack(Material.DISPENSER)
+        Flag.Sponge -> ItemStack(Material.SPONGE)
     }
 }
 
@@ -39,6 +40,7 @@ fun Flag.getDisplayName(): String {
         Flag.Trees -> getLangText("NameFlagTrees")
         Flag.Sculk -> getLangText("NameFlagSculk")
         Flag.Dispensers -> getLangText("NameFlagDispensers")
+        Flag.Sponge -> getLangText("NameFlagSponge")
     }
 }
 
@@ -57,5 +59,6 @@ fun Flag.getDescription(): String {
         Flag.Trees -> getLangText("DescFlagTrees")
         Flag.Sculk -> getLangText("DescFlagSculk")
         Flag.Dispensers -> getLangText("DescFlagDispensers")
+        Flag.Sponge -> getLangText("DescFlagSponge")
     }
 }

--- a/src/main/resources/lang_EN.yml
+++ b/src/main/resources/lang_EN.yml
@@ -7,7 +7,7 @@ NameFlagPistons: "Pistons"
 NameFlagFluids: "Fluid Flow"
 NameFlagTrees: "Tree Growth"
 NameFlagSculk: "Sculk Spread"
-NameFlagDispenser: "Dispense"
+NameFlagDispensers: "Dispense"
 NameFlagSponge: "Sponge Absorb"
 
 DescFlagExplosions: "Allows TNT to damage claim blocks"
@@ -17,7 +17,7 @@ DescFlagPistons: "Allows pistons placed outside the claim to move claim blocks"
 DescFlagFluids: "Allows fluids to flow into the claim"
 DescFlagTrees: "Allows trees planted outside to grow into the claim"
 DescFlagSculk: "Allows sculk catalysts placed outside to grow into the claim"
-DescFlagDispenser: "Allows dispensers placed outside to dispense into the claim"
+DescFlagDispensers: "Allows dispensers placed outside to dispense into the claim"
 DescFlagSponge: "Allows sponges placed outside to drain fluids in the claim"
 
 # --- PermissionDisplay.kt ---

--- a/src/main/resources/lang_EN.yml
+++ b/src/main/resources/lang_EN.yml
@@ -8,6 +8,7 @@ NameFlagFluids: "Fluid Flow"
 NameFlagTrees: "Tree Growth"
 NameFlagSculk: "Sculk Spread"
 NameFlagDispenser: "Dispense"
+NameFlagSponge: "Sponge Absorb"
 
 DescFlagExplosions: "Allows TNT to damage claim blocks"
 DescFlagFireSpread: "Allows fire to spread to other blocks"
@@ -17,6 +18,7 @@ DescFlagFluids: "Allows fluids to flow into the claim"
 DescFlagTrees: "Allows trees planted outside to grow into the claim"
 DescFlagSculk: "Allows sculk catalysts placed outside to grow into the claim"
 DescFlagDispenser: "Allows dispensers placed outside to dispense into the claim"
+DescFlagSponge: "Allows sponges placed outside to drain fluids in the claim"
 
 # --- PermissionDisplay.kt ---
 


### PR DESCRIPTION
New "Sponge Absorb" claim flag has been added, which specifically targets using sponges outside the claim in a body of water that would affect the part of the water that is inside the claim.