### PR TITLE
Add various lightning protections for flag and permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Protection against players triggering a raid through a bad omen effect. Requires the new raid permission.
 - Protection against fluid flow griefing, with players able to place fluids outside of the claim and having it flow into a claim. Bypassed by the new fluid flow flag.
 - Individual flags to allow the claim owner to control the existing tree growth and sculk spread protections.
-- Protection against mobs breaking static entities such as item frames and paintings. Bypassed by the mob griefing flag.
+- Protection against mobs damaging animals and breaking static entities such as item frames and paintings. Bypassed by the mob griefing flag.
 - Protection against trampling using rideable mobs. Requires the build permission.
 - Protection against dispensers placed on the outer edge of the claim being used to grief with fluids or entities such as boats and armor stands. Bypassed by the new dispense flag.
 - Protection against natural lightning causing damage and setting claim blocks alight. Bypassed by the new lightning damage flag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Protection against mobs breaking static entities such as item frames and paintings. Bypassed by the mob griefing flag.
 - Protection against trampling using rideable mobs. Requires the build permission.
 - Protection against dispensers placed on the outer edge of the claim being used to grief with fluids or entities such as boats and armor stands. Bypassed by the new dispense flag.
+- Protection against natural lightning causing damage and setting claim blocks alight. Bypassed by the new lightning damage flag.
+- Protection against lightning damage created by a trident enchanted with channeling. Requires the husbandry permission.
 - Language file support, with all known instances of display text moved to a language file resource.
 - English language complete.
 - Chinese language machine translated. (Temporary, for demonstration)

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
@@ -73,6 +73,10 @@ enum class Flag(val rules: Array<RuleExecutor>) {
 
     Sponge(arrayOf(
         RuleBehaviour.spongeAbsorb
+    )),
+
+    Lightning(arrayOf(
+        RuleBehaviour.lightningDamage
     ));
 
     companion object {

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
@@ -85,7 +85,8 @@ enum class ClaimPermission(val events: Array<PermissionExecutor>) {
         PermissionBehaviour.fishingRod,
         PermissionBehaviour.takeLeadFromFence,
         PermissionBehaviour.beehiveShear,
-        PermissionBehaviour.beehiveBottle
+        PermissionBehaviour.beehiveBottle,
+        PermissionBehaviour.tridentLightningDamage
     )),
 
     /**

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/PermissionBehaviour.kt
@@ -222,7 +222,7 @@ class PermissionBehaviour {
             Companion::getRaidTriggerLocations, Companion::getRaidTriggerPlayer)
 
         // Used to prevent lightning strikes from tridents causing damage in claims
-        val tridentLightningStrike = PermissionExecutor(LightningStrikeEvent::class.java,
+        val tridentLightningDamage = PermissionExecutor(LightningStrikeEvent::class.java,
             Companion::cancelLightningEvent, Companion::getLightningStrikeLocations,
             Companion::getLightningStrikePlayer)
 
@@ -574,6 +574,20 @@ class PermissionBehaviour {
             if (event.hitEntity !is ExplosiveMinecart) return false
             event.isCancelled = true
             return true
+        }
+
+        /**
+         * Cancels the action of lightning attacks using a trident.
+         *
+         * This does not output an alert to the player when the action is performed as it could get annoying for the
+         * alert to appear every time the player throw their trident, which still does projectile damage.
+         */
+        @Suppress("SameReturnValue")
+        private fun cancelLightningEvent(listener: Listener, event: Event): Boolean {
+            if (event !is LightningStrikeEvent) return false
+            event.lightning.flashCount = 0
+            event.lightning.lifeTicks = 0
+            return false
         }
 
         /**

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/PermissionBehaviour.kt
@@ -30,6 +30,7 @@ import org.bukkit.event.inventory.InventoryType
 import org.bukkit.event.player.*
 import org.bukkit.event.raid.RaidTriggerEvent
 import org.bukkit.event.vehicle.VehicleDestroyEvent
+import org.bukkit.event.weather.LightningStrikeEvent
 
 /**
  * A data structure that contains the type of event [eventClass], the function to handle the result of the event
@@ -219,6 +220,11 @@ class PermissionBehaviour {
         // Used for events triggered by an omen status effect
         val triggerRaid = PermissionExecutor(RaidTriggerEvent::class.java, Companion::cancelEvent,
             Companion::getRaidTriggerLocations, Companion::getRaidTriggerPlayer)
+
+        // Used to prevent lightning strikes from tridents causing damage in claims
+        val tridentLightningStrike = PermissionExecutor(LightningStrikeEvent::class.java,
+            Companion::cancelLightningEvent, Companion::getLightningStrikeLocations,
+            Companion::getLightningStrikePlayer)
 
         /**
          * Cancels any cancellable event.
@@ -743,6 +749,14 @@ class PermissionBehaviour {
         }
 
         /**
+         * Gets the affected locations of the LightningStrikeEvent.
+         */
+        private fun getLightningStrikeLocations(event: Event): List<Location> {
+            if (event !is LightningStrikeEvent) return listOf()
+            return listOf(event.lightning.location)
+        }
+
+        /**
          * Gets the player that is triggering the ProjectileHitEvent.
          */
         private fun getProjectileHitPlayer(event: Event): Player? {
@@ -949,6 +963,14 @@ class PermissionBehaviour {
                 return damagingEntity
             }
             return null
+        }
+
+        /**
+         * Gets the player that is triggering the LightningStrikeEvent.
+         */
+        private fun getLightningStrikePlayer(event: Event): Player? {
+            if (event !is LightningStrikeEvent) return null
+            return event.lightning.causingPlayer
         }
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/utils/ClaimFlagDisplay.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/utils/ClaimFlagDisplay.kt
@@ -22,6 +22,7 @@ fun Flag.getIcon(): ItemStack {
         Flag.Sculk -> ItemStack(Material.SCULK_CATALYST)
         Flag.Dispensers -> ItemStack(Material.DISPENSER)
         Flag.Sponge -> ItemStack(Material.SPONGE)
+        Flag.Lightning -> ItemStack(Material.LIGHTNING_ROD)
     }
 }
 
@@ -41,6 +42,7 @@ fun Flag.getDisplayName(): String {
         Flag.Sculk -> getLangText("NameFlagSculk")
         Flag.Dispensers -> getLangText("NameFlagDispensers")
         Flag.Sponge -> getLangText("NameFlagSponge")
+        Flag.Lightning -> getLangText("NameFlagLightning")
     }
 }
 
@@ -60,5 +62,6 @@ fun Flag.getDescription(): String {
         Flag.Sculk -> getLangText("DescFlagSculk")
         Flag.Dispensers -> getLangText("DescFlagDispensers")
         Flag.Sponge -> getLangText("DescFlagSponge")
+        Flag.Lightning -> getLangText("DescFlagLightning")
     }
 }

--- a/src/main/resources/lang_EN.yml
+++ b/src/main/resources/lang_EN.yml
@@ -9,6 +9,7 @@ NameFlagTrees: "Tree Growth"
 NameFlagSculk: "Sculk Spread"
 NameFlagDispensers: "Dispense"
 NameFlagSponge: "Sponge Absorb"
+NameFlagLightning: "Lightning Damage"
 
 DescFlagExplosions: "Allows TNT to damage claim blocks"
 DescFlagFireSpread: "Allows fire to spread to other blocks"
@@ -19,6 +20,7 @@ DescFlagTrees: "Allows trees planted outside to grow into the claim"
 DescFlagSculk: "Allows sculk catalysts placed outside to grow into the claim"
 DescFlagDispensers: "Allows dispensers placed outside to dispense into the claim"
 DescFlagSponge: "Allows sponges placed outside to drain fluids in the claim"
+DescFlagLightning: "Allows lightning to cause damage and set the ground alight"
 
 # --- PermissionDisplay.kt ---
 


### PR DESCRIPTION
This is a double whammy, which covers separate protections for natural and player generated lightning.

Natural lightning is covered by the new "Lightning Damage" flag, which disallows lightning from being able to cause damage and set claim blocks alight.

Player generated lightning is usually caused by tridents enchanted with channeling. While ideally this should only stop the damage being done to passive mobs, I couldn't find a way to control lightning that fine grained, so it just doesn't do damage altogether. The trident will still do damage to the target, and the lightning will still flash briefly, but no additional damage is done by the lightning.