### PR TITLE
Added new protection flag against falling block launching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Protection against dispensers placed on the outer edge of the claim being used to grief with fluids or entities such as boats and armor stands. Bypassed by the new dispense flag.
 - Protection against natural lightning causing damage and setting claim blocks alight. Bypassed by the new lightning damage flag.
 - Protection against lightning damage created by a trident enchanted with channeling. Requires the husbandry permission.
+- Protection against falling blocks being launched into the claim. Bypassed by the block launch flag.
 - Language file support, with all known instances of display text moved to a language file resource.
 - English language complete.
 - Chinese language machine translated. (Temporary, for demonstration)

--- a/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
@@ -235,5 +235,6 @@ class BellClaims : JavaPlugin() {
                 playerStateService, visualisationService), this)
         server.pluginManager.registerEvents(
             PartitionUpdateListener(claimService, partitionService, playerStateService, visualiser), this)
+        server.pluginManager.registerEvents(BlockLaunchListener(this), this)
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
@@ -77,6 +77,10 @@ enum class Flag(val rules: Array<RuleExecutor>) {
 
     Lightning(arrayOf(
         RuleBehaviour.lightningDamage
+    )),
+
+    FallingBlock(arrayOf(
+        RuleBehaviour.blockFall
     ));
 
     companion object {

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/BlockLaunchListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/BlockLaunchListener.kt
@@ -1,0 +1,18 @@
+package dev.mizarc.bellclaims.interaction.listeners
+
+import org.bukkit.Material
+import org.bukkit.entity.FallingBlock
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.entity.EntityChangeBlockEvent
+import org.bukkit.metadata.FixedMetadataValue
+import org.bukkit.plugin.java.JavaPlugin
+
+class BlockLaunchListener(private val plugin: JavaPlugin): Listener {
+    @EventHandler
+    fun onBlockLaunch(event: EntityChangeBlockEvent) {
+        if (event.entity !is FallingBlock) return
+        if (event.to != Material.AIR) return
+        event.entity.setMetadata("origin_location", FixedMetadataValue(plugin, event.block.location))
+    }
+}

--- a/src/main/kotlin/dev/mizarc/bellclaims/utils/ClaimFlagDisplay.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/utils/ClaimFlagDisplay.kt
@@ -44,7 +44,7 @@ fun Flag.getDisplayName(): String {
         Flag.Dispensers -> getLangText("NameFlagDispensers")
         Flag.Sponge -> getLangText("NameFlagSponge")
         Flag.Lightning -> getLangText("NameFlagLightning")
-        Flag.FallingBlock -> getLangText("NameFallingBlock")
+        Flag.FallingBlock -> getLangText("NameFlagFallingBlock")
     }
 }
 
@@ -65,6 +65,6 @@ fun Flag.getDescription(): String {
         Flag.Dispensers -> getLangText("DescFlagDispensers")
         Flag.Sponge -> getLangText("DescFlagSponge")
         Flag.Lightning -> getLangText("DescFlagLightning")
-        Flag.FallingBlock -> getLangText("DescFallingBlock")
+        Flag.FallingBlock -> getLangText("DescFlagFallingBlock")
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/utils/ClaimFlagDisplay.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/utils/ClaimFlagDisplay.kt
@@ -23,6 +23,7 @@ fun Flag.getIcon(): ItemStack {
         Flag.Dispensers -> ItemStack(Material.DISPENSER)
         Flag.Sponge -> ItemStack(Material.SPONGE)
         Flag.Lightning -> ItemStack(Material.LIGHTNING_ROD)
+        Flag.FallingBlock -> ItemStack(Material.ANVIL)
     }
 }
 
@@ -43,6 +44,7 @@ fun Flag.getDisplayName(): String {
         Flag.Dispensers -> getLangText("NameFlagDispensers")
         Flag.Sponge -> getLangText("NameFlagSponge")
         Flag.Lightning -> getLangText("NameFlagLightning")
+        Flag.FallingBlock -> getLangText("NameFallingBlock")
     }
 }
 
@@ -63,5 +65,6 @@ fun Flag.getDescription(): String {
         Flag.Dispensers -> getLangText("DescFlagDispensers")
         Flag.Sponge -> getLangText("DescFlagSponge")
         Flag.Lightning -> getLangText("DescFlagLightning")
+        Flag.FallingBlock -> getLangText("DescFallingBlock")
     }
 }

--- a/src/main/resources/lang_EN.yml
+++ b/src/main/resources/lang_EN.yml
@@ -10,6 +10,7 @@ NameFlagSculk: "Sculk Spread"
 NameFlagDispensers: "Dispense"
 NameFlagSponge: "Sponge Absorb"
 NameFlagLightning: "Lightning Damage"
+NameFlagFallingBlock: "Block Launching"
 
 DescFlagExplosions: "Allows TNT to damage claim blocks"
 DescFlagFireSpread: "Allows fire to spread to other blocks"
@@ -21,6 +22,7 @@ DescFlagSculk: "Allows sculk catalysts placed outside to grow into the claim"
 DescFlagDispensers: "Allows dispensers placed outside to dispense into the claim"
 DescFlagSponge: "Allows sponges placed outside to drain fluids in the claim"
 DescFlagLightning: "Allows lightning to cause damage and set the ground alight"
+DescFlagFallingBlock: "Allows blocks such as sand and anvils to be launched into the claim"
 
 # --- PermissionDisplay.kt ---
 


### PR DESCRIPTION
Falling blocks can be utilised to grief a claim, as players are able to set up block launchers to launch a falling block from outside a claim into a claimed area. This protection denies their ability to do so, dropping the falling block as an item if it lands inside of a claim.