### PR TITLE
Added protection against splash and lingering potions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,16 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ## [Latest]
 
 ### Added
+- Individual flags to allow the claim owner to control the existing tree growth and sculk spread protections.
 - Protection against players triggering a raid through a bad omen effect. Requires the new raid permission.
 - Protection against fluid flow griefing, with players able to place fluids outside of the claim and having it flow into a claim. Bypassed by the new fluid flow flag.
-- Individual flags to allow the claim owner to control the existing tree growth and sculk spread protections.
 - Protection against mobs damaging animals and breaking static entities such as item frames and paintings. Bypassed by the mob griefing flag.
 - Protection against trampling using rideable mobs. Requires the build permission.
 - Protection against dispensers placed on the outer edge of the claim being used to grief with fluids or entities such as boats and armor stands. Bypassed by the new dispense flag.
 - Protection against natural lightning causing damage and setting claim blocks alight. Bypassed by the new lightning damage flag.
 - Protection against lightning damage created by a trident enchanted with channeling. Requires the husbandry permission.
 - Protection against falling blocks being launched into the claim. Bypassed by the block launch flag.
+- Protection against splash and lingering potions affecting passive mobs. Requires the husbandry permission.
 - Language file support, with all known instances of display text moved to a language file resource.
 - English language complete.
 - Chinese language machine translated. (Temporary, for demonstration)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Protection against lightning damage created by a trident enchanted with channeling. Requires the husbandry permission.
 - Protection against falling blocks being launched into the claim. Bypassed by the block launch flag.
 - Protection against splash and lingering potions affecting passive mobs. Requires the husbandry permission.
+- Protection against dispensed potions affecting players and passive mobs. Bypassed by the dispenser flag.
 - Language file support, with all known instances of display text moved to a language file resource.
 - English language complete.
 - Chinese language machine translated. (Temporary, for demonstration)

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
@@ -68,7 +68,9 @@ enum class Flag(val rules: Array<RuleExecutor>) {
     )),
 
     Dispensers(arrayOf(
-        RuleBehaviour.dispense
+        RuleBehaviour.dispense,
+        RuleBehaviour.dispensedSplashPotion,
+        RuleBehaviour.dispensedLingeringPotion
     )),
 
     Sponge(arrayOf(

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
@@ -87,7 +87,8 @@ enum class ClaimPermission(val events: Array<PermissionExecutor>) {
         PermissionBehaviour.beehiveShear,
         PermissionBehaviour.beehiveBottle,
         PermissionBehaviour.tridentLightningDamage,
-        PermissionBehaviour.potionSplash
+        PermissionBehaviour.potionSplash,
+        PermissionBehaviour.potionLinger
     )),
 
     /**

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
@@ -86,7 +86,8 @@ enum class ClaimPermission(val events: Array<PermissionExecutor>) {
         PermissionBehaviour.takeLeadFromFence,
         PermissionBehaviour.beehiveShear,
         PermissionBehaviour.beehiveBottle,
-        PermissionBehaviour.tridentLightningDamage
+        PermissionBehaviour.tridentLightningDamage,
+        PermissionBehaviour.potionSplash
     )),
 
     /**

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -666,7 +666,7 @@ class RuleBehaviour {
                                              partitionService: PartitionService, flagService: FlagService): Boolean {
             if (event !is PotionSplashEvent) return false
             for (entity in event.affectedEntities) {
-                if (entity !is Monster && entity !is Player) {
+                if (entity !is Monster) {
                     event.setIntensity(entity, 0.0)
                 }
             }
@@ -688,7 +688,7 @@ class RuleBehaviour {
         private fun cancelLingeringPotionEffect(event: Event, claimService: ClaimService,
                                                 partitionService: PartitionService, flagService: FlagService): Boolean {
             if (event !is AreaEffectCloudApplyEvent) return false
-            event.affectedEntities.removeAll { it !is Monster && it !is Player }
+            event.affectedEntities.removeAll { it !is Monster }
             return false
         }
     }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -17,7 +17,6 @@ import dev.mizarc.bellclaims.domain.flags.Flag
 import org.bukkit.Location
 import org.bukkit.block.BlockState
 import org.bukkit.block.data.Directional
-import org.bukkit.block.data.type.Light
 import org.bukkit.entity.*
 import org.bukkit.event.entity.EntityBreakDoorEvent
 import org.bukkit.event.entity.EntityDamageByBlockEvent
@@ -28,7 +27,6 @@ import org.bukkit.event.hanging.HangingBreakEvent
 import org.bukkit.event.weather.LightningStrikeEvent
 import org.bukkit.event.world.StructureGrowEvent
 import org.bukkit.inventory.ItemStack
-import org.bukkit.metadata.FixedMetadataValue
 
 /**
  * A data structure that contains the type of event [eventClass], the function to handle the result of the event

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -18,10 +18,12 @@ import org.bukkit.Location
 import org.bukkit.block.BlockState
 import org.bukkit.block.data.Directional
 import org.bukkit.entity.*
+import org.bukkit.event.entity.AreaEffectCloudApplyEvent
 import org.bukkit.event.entity.EntityBreakDoorEvent
 import org.bukkit.event.entity.EntityDamageByBlockEvent
 import org.bukkit.event.entity.EntityDamageByEntityEvent
 import org.bukkit.event.entity.EntityDamageEvent
+import org.bukkit.event.entity.PotionSplashEvent
 import org.bukkit.event.hanging.HangingBreakByEntityEvent
 import org.bukkit.event.hanging.HangingBreakEvent
 import org.bukkit.event.weather.LightningStrikeEvent
@@ -87,6 +89,10 @@ class RuleBehaviour {
             Companion::blockSpreadInClaim)
         val dispense = RuleExecutor(BlockDispenseEvent::class.java, Companion::cancelEvent,
             Companion::blockDispenseInClaim)
+        val dispensedSplashPotion = RuleExecutor(PotionSplashEvent::class.java,
+            Companion::cancelSplashPotionEffect, Companion::potionSplashInClaim)
+        val dispensedLingeringPotion = RuleExecutor(AreaEffectCloudApplyEvent::class.java,
+            Companion::cancelLingeringPotionEffect, Companion::areaEffectCloudApplyInClaim)
         val spongeAbsorb = RuleExecutor(SpongeAbsorbEvent::class.java, Companion::cancelSpongeAbsorbEvent,
             Companion::spongeAbsorbInClaim)
         val lightningDamage = RuleExecutor(LightningStrikeEvent::class.java, Companion::cancelLightningStrikeEvent,
@@ -642,6 +648,48 @@ class RuleBehaviour {
             event.isCancelled = true
             event.block.world.dropItemNaturally(fallingBlock.location, itemStack)
             return true
+        }
+
+        private fun potionSplashInClaim(event: Event, claimService: ClaimService,
+                                        partitionService: PartitionService): List<Claim> {
+            if (event !is PotionSplashEvent) return listOf()
+            val affectedClaims = mutableListOf<Claim>()
+            for (entity in event.affectedEntities) {
+                val partition = partitionService.getByLocation(entity.location) ?: continue
+                val claim = claimService.getById(partition.claimId) ?: continue
+                affectedClaims.add(claim)
+            }
+            return affectedClaims
+        }
+
+        private fun cancelSplashPotionEffect(event: Event, claimService: ClaimService,
+                                             partitionService: PartitionService, flagService: FlagService): Boolean {
+            if (event !is PotionSplashEvent) return false
+            for (entity in event.affectedEntities) {
+                if (entity !is Monster && entity !is Player) {
+                    event.setIntensity(entity, 0.0)
+                }
+            }
+            return true
+        }
+
+        private fun areaEffectCloudApplyInClaim(event: Event, claimService: ClaimService,
+                                                partitionService: PartitionService): List<Claim> {
+            if (event !is AreaEffectCloudApplyEvent) return listOf()
+            val affectedClaims = mutableListOf<Claim>()
+            for (entity in event.affectedEntities) {
+                val partition = partitionService.getByLocation(entity.location) ?: continue
+                val claim = claimService.getById(partition.claimId) ?: continue
+                affectedClaims.add(claim)
+            }
+            return affectedClaims
+        }
+
+        private fun cancelLingeringPotionEffect(event: Event, claimService: ClaimService,
+                                                partitionService: PartitionService, flagService: FlagService): Boolean {
+            if (event !is AreaEffectCloudApplyEvent) return false
+            event.affectedEntities.removeAll { it !is Monster && it !is Player }
+            return false
         }
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/ClaimManagementMenu.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/ClaimManagementMenu.kt
@@ -323,7 +323,7 @@ class ClaimManagementMenu(private val claimService: ClaimService,
 
     fun openClaimFlagMenu(claim: Claim) {
         // Create claim flags menu
-        val gui = ChestGui(5, "Claim Flags")
+        val gui = ChestGui(6, "Claim Flags")
         gui.setOnTopClick { guiEvent -> guiEvent.isCancelled = true }
         gui.setOnBottomClick { guiEvent -> if (guiEvent.click == ClickType.SHIFT_LEFT ||
             guiEvent.click == ClickType.SHIFT_RIGHT) guiEvent.isCancelled = true }
@@ -368,7 +368,7 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         // Add vertical divider
         val verticalDividerPane = StaticPane(4, 2, 1, 6)
         gui.addPane(verticalDividerPane)
-        for (slot in 0..2) {
+        for (slot in 0..3) {
             verticalDividerPane.addItem(guiDividerItem, 0, slot)
         }
 


### PR DESCRIPTION
This is a protection that covers both a permission and a flag:

The permission element prevents player thrown potions from affecting passive mobs as a means to grief. This is covered by the husbandry permission.

The flag element prevents dispensed potions from affecting both passive mobs and players. The reason why it shouldn't affect players is because with player thrown potions, the intent is to keep the PVP element to it, as you can kill the player to stop them from throwing potions at you. With dispensers, the player who set up the dispenser could put it down in a protected area, removing your ability to stop the source of the potions.