### PR TITLE
Added protection against sleeping in beds or setting spawn points at respawn anchors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Protection against falling blocks being launched into the claim. Bypassed by the block launch flag.
 - Protection against splash and lingering potions affecting passive mobs. Requires the husbandry permission.
 - Protection against dispensed potions affecting players and passive mobs. Bypassed by the dispenser flag.
+- Protection against sleeping in beds and setting respawn points at respawn anchors. Requires the new sleep permission.
 - Language file support, with all known instances of display text moved to a language file resource.
 - English language complete.
 - Chinese language machine translated. (Temporary, for demonstration)

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
@@ -107,6 +107,14 @@ enum class ClaimPermission(val events: Array<PermissionExecutor>) {
      */
     EventStart(arrayOf(
         PermissionBehaviour.triggerRaid
+    )),
+
+    /**
+     * When a player sleeps in a bed or uses a respawn anchor.
+     */
+    Sleep(arrayOf(
+        PermissionBehaviour.bedSleep,
+        PermissionBehaviour.respawnSet
     ));
 
     companion object {

--- a/src/main/kotlin/dev/mizarc/bellclaims/utils/PermissionDisplay.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/utils/PermissionDisplay.kt
@@ -24,6 +24,7 @@ fun ClaimPermission.getIcon(): ItemStack {
         ClaimPermission.Husbandry -> ItemStack(Material.LEAD)
         ClaimPermission.Detonate -> ItemStack(Material.TNT)
         ClaimPermission.EventStart -> ItemStack(Material.OMINOUS_BOTTLE)
+        ClaimPermission.Sleep -> ItemStack(Material.RED_BED)
     }
 }
 
@@ -45,6 +46,7 @@ fun ClaimPermission.getDisplayName(): String {
         ClaimPermission.Husbandry -> getLangText("NameClaimPermissionHusbandry")
         ClaimPermission.Detonate -> getLangText("NameClaimPermissionDetonate")
         ClaimPermission.EventStart -> getLangText("NameClaimPermissionEventStart")
+        ClaimPermission.Sleep -> getLangText("NameClaimPermissionSleep")
     }
 }
 
@@ -66,5 +68,6 @@ fun ClaimPermission.getDescription(): String {
         ClaimPermission.Husbandry -> getLangText("DescClaimPermissionHusbandry")
         ClaimPermission.Detonate -> getLangText("DescClaimPermissionDetonate")
         ClaimPermission.EventStart -> getLangText("DescClaimPermissionEventStart")
+        ClaimPermission.Sleep -> getLangText("DescClaimPermissionSleep")
     }
 }

--- a/src/main/resources/lang_EN.yml
+++ b/src/main/resources/lang_EN.yml
@@ -37,6 +37,7 @@ NameClaimPermissionVillagerTrade: "Trade Villagers"
 NameClaimPermissionHusbandry: "Husbandry"
 NameClaimPermissionDetonate: "Detonate"
 NameClaimPermissionEventStart: "Raid"
+NameClaimPermissionSleep: "Sleep"
 
 DescClaimPermissionBuild: "Grants permission to build"
 DescClaimPermissionContainerInspect: "Grants permission to open inventories (Chest, Furnace, Anvil)"
@@ -49,6 +50,7 @@ DescClaimPermissionVillagerTrade: "Grants permission to trade with villagers"
 DescClaimPermissionHusbandry: "Grants permission to interact with passive animals"
 DescClaimPermissionDetonate: "Grants permission to directly set off explosives"
 DescClaimPermissionEventStart: "Grants permission to start a raid event"
+DescClaimPermissionSleep: "Grants permission to sleep and set respawn points at a respawn anchor."
 
 # --- ClaimManagementMenu.kt ---
 


### PR DESCRIPTION
This is a pretty simple permission that does what it says on the tin. Players who do not have this permission cannot use beds or respawn anchors in the claim.