### PR TITLE
Add minimum partition and initial claim size options in the config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Protection against splash and lingering potions affecting passive mobs. Requires the husbandry permission.
 - Protection against dispensed potions affecting players and passive mobs. Bypassed by the dispenser flag.
 - Protection against sleeping in beds and setting respawn points at respawn anchors. Requires the new sleep permission.
+- Config value for setting the initial claim size.
+- Config value for setting the minimum partition size.
 - Language file support, with all known instances of display text moved to a language file resource.
 - English language complete.
 - Chinese language machine translated. (Temporary, for demonstration)
@@ -27,6 +29,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 - Piston protection now only applies if the piston affecting the claim blocks is outside of the claim.
+- Config keys are no longer auto added and have a fixed structure, default values are applied when values are missing.
 
 ### Fixed
 - Multi-blocks bypassing protections when the source is placed outside of the claim.

--- a/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
@@ -158,7 +158,7 @@ class BellClaims : JavaPlugin() {
         playerStateService = PlayerStateServiceImpl(playerStateRepo)
         claimService = ClaimServiceImpl(claimRepo, partitionRepo, claimFlagRepo, claimPermissionRepo, playerAccessRepo)
         partitionService = PartitionServiceImpl(config, partitionRepo, claimService, playerLimitService)
-        claimWorldService = ClaimWorldServiceImpl(claimRepo, partitionService, playerLimitService)
+        claimWorldService = ClaimWorldServiceImpl(claimRepo, partitionService, playerLimitService, config)
         flagService = FlagServiceImpl(claimFlagRepo)
         defaultPermissionService = DefaultPermissionServiceImpl(claimPermissionRepo)
         playerPermissionService = PlayerPermissionServiceImpl(playerAccessRepo)
@@ -219,7 +219,7 @@ class BellClaims : JavaPlugin() {
                 playerPermissionService, playerStateService), this)
         server.pluginManager.registerEvents(
             EditToolListener(claimRepo, partitionService, playerLimitService, playerStateService, claimService,
-                visualiser), this)
+                visualiser, config), this)
         server.pluginManager.registerEvents(
             EditToolVisualisingListener(this, playerStateService, visualiser), this)
         server.pluginManager.registerEvents(PlayerRegistrationListener(playerStateService), this)

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/persistence/Config.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/persistence/Config.kt
@@ -8,6 +8,7 @@ class Config(val plugin: Plugin) {
 
     var claimLimit = 0
     var claimBlockLimit = 0
+    var initialClaimSize = 0
     var minimumPartitionSize = 0
     var distanceBetweenClaims = 0
     var pluginLanguage = "EN"
@@ -20,6 +21,7 @@ class Config(val plugin: Plugin) {
     fun loadConfig() {
         claimLimit = configFile.getInt("claim_limit")
         claimBlockLimit = configFile.getInt("claim_block_limit")
+        initialClaimSize = configFile.getInt("initial_claim_size")
         minimumPartitionSize = configFile.getInt("minimum_partition_size")
         distanceBetweenClaims = configFile.getInt("distance_between_claims")
         pluginLanguage = configFile.getString("plugin_language") ?: "EN"
@@ -31,18 +33,5 @@ class Config(val plugin: Plugin) {
         if (!configFile.exists()) {
             plugin.saveResource("config.yml", false)
         }
-
-        //disabled for comments in config.yml
-        /*
-        plugin.config.addDefault("claim_limit", 3)
-        plugin.config.addDefault("claim_block_limit", 5000)
-        plugin.config.addDefault("minimum_claim_size", 5)
-        plugin.config.addDefault("distance_between_claims", 3)
-        plugin.config.addDefault("plugin_language", "EN")
-
-        plugin.config.options().copyDefaults(true)
-        plugin.saveConfig()
-        */
-
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/persistence/Config.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/persistence/Config.kt
@@ -8,7 +8,7 @@ class Config(val plugin: Plugin) {
 
     var claimLimit = 0
     var claimBlockLimit = 0
-    var minimumClaimSize = 0
+    var minimumPartitionSize = 0
     var distanceBetweenClaims = 0
     var pluginLanguage = "EN"
 
@@ -20,7 +20,7 @@ class Config(val plugin: Plugin) {
     fun loadConfig() {
         claimLimit = configFile.getInt("claim_limit")
         claimBlockLimit = configFile.getInt("claim_block_limit")
-        minimumClaimSize = configFile.getInt("minimum_claim_size")
+        minimumPartitionSize = configFile.getInt("minimum_partition_size")
         distanceBetweenClaims = configFile.getInt("distance_between_claims")
         pluginLanguage = configFile.getString("plugin_language") ?: "EN"
     }

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/persistence/Config.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/persistence/Config.kt
@@ -23,7 +23,7 @@ class Config(val plugin: Plugin) {
         claimBlockLimit = configFile.getInt("claim_block_limit")
         initialClaimSize = maxOf(3,configFile.getInt("initial_claim_size"))
         minimumPartitionSize = maxOf(3, configFile.getInt("minimum_partition_size"))
-        distanceBetweenClaims = maxOf(3, configFile.getInt("distance_between_claims"))
+        distanceBetweenClaims = configFile.getInt("distance_between_claims")
         pluginLanguage = configFile.getString("plugin_language") ?: "EN"
     }
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/persistence/Config.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/persistence/Config.kt
@@ -21,9 +21,9 @@ class Config(val plugin: Plugin) {
     fun loadConfig() {
         claimLimit = configFile.getInt("claim_limit")
         claimBlockLimit = configFile.getInt("claim_block_limit")
-        initialClaimSize = configFile.getInt("initial_claim_size")
-        minimumPartitionSize = configFile.getInt("minimum_partition_size")
-        distanceBetweenClaims = configFile.getInt("distance_between_claims")
+        initialClaimSize = maxOf(3,configFile.getInt("initial_claim_size"))
+        minimumPartitionSize = maxOf(3, configFile.getInt("minimum_partition_size"))
+        distanceBetweenClaims = maxOf(3, configFile.getInt("distance_between_claims"))
         pluginLanguage = configFile.getString("plugin_language") ?: "EN"
     }
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/ClaimWorldServiceImpl.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/ClaimWorldServiceImpl.kt
@@ -39,11 +39,10 @@ class ClaimWorldServiceImpl(private val claimRepo: ClaimRepository,
     }
 
     override fun create(name: String, location: Location, player: OfflinePlayer): ClaimCreationResult {
+        val halfSize = (config.initialClaimSize.toFloat() - 1) / 2
         val area = Area(
-            Position2D(location.blockX - floor(config.initialClaimSize.toFloat() / 2).toInt(),
-                location.blockZ - floor(config.initialClaimSize.toFloat() / 2).toInt()),
-            Position2D(location.blockX + ceil(config.initialClaimSize.toFloat() / 2).toInt(),
-                location.blockZ + ceil(config.initialClaimSize.toFloat() / 2).toInt()))
+            Position2D((location.blockX - floor(halfSize)).toInt(), (location.blockZ - floor(halfSize)).toInt()),
+            Position2D((location.blockX + ceil(halfSize)).toInt(),(location.blockZ + ceil(halfSize)).toInt()))
 
         // Handle failure types
         if (location.block.type != Material.BELL) return ClaimCreationResult.NOT_A_BELL

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/ClaimWorldServiceImpl.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/ClaimWorldServiceImpl.kt
@@ -11,13 +11,17 @@ import dev.mizarc.bellclaims.domain.claims.ClaimRepository
 import dev.mizarc.bellclaims.domain.partitions.Area
 import dev.mizarc.bellclaims.domain.partitions.Position2D
 import dev.mizarc.bellclaims.domain.partitions.Position3D
+import dev.mizarc.bellclaims.infrastructure.persistence.Config
 import org.bukkit.Location
 import org.bukkit.Material
 import org.bukkit.OfflinePlayer
+import kotlin.math.ceil
+import kotlin.math.floor
 
 class ClaimWorldServiceImpl(private val claimRepo: ClaimRepository,
                             private val partitionService: PartitionService,
-                            private val playerLimitService: PlayerLimitService): ClaimWorldService {
+                            private val playerLimitService: PlayerLimitService,
+                            private val config: Config): ClaimWorldService {
     override fun isNewLocationValid(location: Location): Boolean {
         val area = Area(
             Position2D(location.blockX - 5, location.blockZ - 5),
@@ -36,8 +40,10 @@ class ClaimWorldServiceImpl(private val claimRepo: ClaimRepository,
 
     override fun create(name: String, location: Location, player: OfflinePlayer): ClaimCreationResult {
         val area = Area(
-            Position2D(location.blockX - 5, location.blockZ - 5),
-            Position2D(location.blockX + 5, location.blockZ + 5))
+            Position2D(location.blockX - floor(config.initialClaimSize.toFloat() / 2).toInt(),
+                location.blockZ - floor(config.initialClaimSize.toFloat() / 2).toInt()),
+            Position2D(location.blockX + ceil(config.initialClaimSize.toFloat() / 2).toInt(),
+                location.blockZ + ceil(config.initialClaimSize.toFloat() / 2).toInt()))
 
         // Handle failure types
         if (location.block.type != Material.BELL) return ClaimCreationResult.NOT_A_BELL

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/PartitionServiceImpl.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/PartitionServiceImpl.kt
@@ -81,7 +81,8 @@ class PartitionServiceImpl(private val config: Config,
         if (isPartitionTooClose(partition)) return PartitionCreationResult.TOO_CLOSE
 
         // Check if claim meets minimum size
-        if (area.getXLength() < 3 || area.getZLength() < 3) return PartitionCreationResult.TOO_SMALL
+        if (area.getXLength() < config.minimumPartitionSize ||
+                area.getZLength() < config.minimumPartitionSize) return PartitionCreationResult.TOO_SMALL
 
         // Check if selection is greater than the player's remaining claim blocks
         val remainingClaimBlockCount = playerLimitService.getRemainingClaimBlockCount(claim.owner)
@@ -126,7 +127,8 @@ class PartitionServiceImpl(private val config: Config,
             return PartitionResizeResult.EXPOSED_CLAIM_HUB
 
         // Check if claim meets minimum size
-        if (newPartition.area.getXLength() < 3 || newPartition.area.getZLength() < 3)
+        if (newPartition.area.getXLength() < config.minimumPartitionSize ||
+                newPartition.area.getZLength() < config.minimumPartitionSize)
             return PartitionResizeResult.TOO_SMALL
 
         // Check if claim takes too much space

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolListener.kt
@@ -23,6 +23,7 @@ import dev.mizarc.bellclaims.infrastructure.getClaimTool
 import dev.mizarc.bellclaims.domain.partitions.Position2D
 import dev.mizarc.bellclaims.interaction.menus.EditToolMenu
 import dev.mizarc.bellclaims.domain.partitions.Partition
+import dev.mizarc.bellclaims.infrastructure.persistence.Config
 import dev.mizarc.bellclaims.interaction.visualisation.Visualiser
 import java.util.*
 
@@ -37,7 +38,8 @@ class EditToolListener(private val claims: ClaimRepository,
                        private val playerLimitService: PlayerLimitService,
                        private val playerStateService: PlayerStateService,
                        private val claimService: ClaimService,
-                       private val visualiser: Visualiser) : Listener {
+                       private val visualiser: Visualiser,
+                       private val config: Config) : Listener {
     private var partitionBuilders = mutableMapOf<Player, Partition.Builder>()
     private var partitionResizers = mutableMapOf<Player, Partition.Resizer>()
 
@@ -166,7 +168,8 @@ class EditToolListener(private val claims: ClaimRepository,
                 return player.sendActionBar(Component.text("That selection is too close to another claim")
                     .color(TextColor.color(255, 85, 85)))
             PartitionCreationResult.TOO_SMALL ->
-                return player.sendActionBar(Component.text("The claim must be at least 3x3 blocks")
+                return player.sendActionBar(Component.text("The selection must be at least " +
+                        "${config.minimumPartitionSize}x${config.minimumPartitionSize} blocks")
                     .color(TextColor.color(255, 85, 85)))
             PartitionCreationResult.INSUFFICIENT_BLOCKS ->
                 return player.sendActionBar(Component.text("That selection would require an additional " +
@@ -247,7 +250,8 @@ class EditToolListener(private val claims: ClaimRepository,
                         "being outside the claim area")
                     .color(TextColor.color(255, 85, 85)))
             PartitionResizeResult.TOO_SMALL ->
-                player.sendActionBar(Component.text("The claim must be at least 3x3 blocks")
+                player.sendActionBar(Component.text("The selection must be at least " +
+                        "${config.minimumPartitionSize}x${config.minimumPartitionSize} blocks")
                     .color(TextColor.color(255, 85, 85)))
             PartitionResizeResult.DISCONNECTED ->
                 player.sendActionBar(Component.text("Resizing to that size would result in a gap between " +

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,8 +1,8 @@
 claim_limit: 3
 claim_block_limit: 5000
-initial_claim_size: 5
-minimum_partition_size: 3
-distance_between_claims: 3
+initial_claim_size: 5 # Minimum value of 3
+minimum_partition_size: 3 # Minimum value of 3
+distance_between_claims: 3 # Minimum value of 3
 plugin_language: EN
 
 #NOT COMPLETED

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2,7 +2,7 @@ claim_limit: 3
 claim_block_limit: 5000
 initial_claim_size: 7 # Minimum value of 3
 minimum_partition_size: 3 # Minimum value of 3
-distance_between_claims: 3
+distance_between_claims: 1
 plugin_language: EN
 
 #NOT COMPLETED

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,6 +1,7 @@
 claim_limit: 3
 claim_block_limit: 5000
-minimum_partition_size: 5
+initial_claim_size: 5
+minimum_partition_size: 3
 distance_between_claims: 3
 plugin_language: EN
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2,7 +2,7 @@ claim_limit: 3
 claim_block_limit: 5000
 initial_claim_size: 5 # Minimum value of 3
 minimum_partition_size: 3 # Minimum value of 3
-distance_between_claims: 3 # Minimum value of 3
+distance_between_claims: 3
 plugin_language: EN
 
 #NOT COMPLETED

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,6 +1,6 @@
 claim_limit: 3
 claim_block_limit: 5000
-initial_claim_size: 5 # Minimum value of 3
+initial_claim_size: 7 # Minimum value of 3
 minimum_partition_size: 3 # Minimum value of 3
 distance_between_claims: 3
 plugin_language: EN

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,6 +1,6 @@
 claim_limit: 3
 claim_block_limit: 5000
-minimum_claim_size: 5
+minimum_partition_size: 5
 distance_between_claims: 3
 plugin_language: EN
 

--- a/src/test/kotlin/dev/mizarc/bellclaims/infrastructure/services/ClaimWorldServiceImplTest.kt
+++ b/src/test/kotlin/dev/mizarc/bellclaims/infrastructure/services/ClaimWorldServiceImplTest.kt
@@ -1,5 +1,6 @@
 package dev.mizarc.bellclaims.infrastructure.services
 
+import dev.mizarc.bellclaims.BellClaims
 import dev.mizarc.bellclaims.api.ClaimWorldService
 import dev.mizarc.bellclaims.api.PartitionService
 import dev.mizarc.bellclaims.api.PlayerLimitService
@@ -13,6 +14,7 @@ import dev.mizarc.bellclaims.domain.partitions.Area
 import dev.mizarc.bellclaims.domain.partitions.Partition
 import dev.mizarc.bellclaims.domain.partitions.Position2D
 import dev.mizarc.bellclaims.domain.partitions.Position3D
+import dev.mizarc.bellclaims.infrastructure.persistence.Config
 import io.mockk.*
 import org.bukkit.Location
 import org.bukkit.Material
@@ -29,6 +31,7 @@ class ClaimWorldServiceImplTest {
     private lateinit var partitionService: PartitionService
     private lateinit var playerLimitService: PlayerLimitService
     private lateinit var claimWorldService: ClaimWorldService
+    private lateinit var config: Config
 
     private lateinit var playerOne: OfflinePlayer
     private lateinit var playerTwo: OfflinePlayer
@@ -42,10 +45,17 @@ class ClaimWorldServiceImplTest {
 
     @BeforeEach
     fun setup() {
+        config = mockk()
+        every { config.minimumPartitionSize } returns 3
+        every { config.distanceBetweenClaims } returns 1
+        every { config.initialClaimSize } returns 7
+        every { config.claimLimit } returns 3
+        every { config.claimBlockLimit } returns 50000
+
         claimRepo = mockk()
         partitionService = mockk()
         playerLimitService = mockk()
-        claimWorldService = ClaimWorldServiceImpl(claimRepo, partitionService, playerLimitService)
+        claimWorldService = ClaimWorldServiceImpl(claimRepo, partitionService, playerLimitService, config)
 
         playerOne = mockk<OfflinePlayer>()
         playerTwo = mockk<OfflinePlayer>()
@@ -60,6 +70,8 @@ class ClaimWorldServiceImplTest {
         partitionCollectionTwo = arrayOf(
             Partition(UUID.randomUUID(), claimTwo.id, Area(Position2D(17, 29), Position2D(23, 39))),
             Partition(UUID.randomUUID(), claimTwo.id, Area(Position2D(11, 37), Position2D(16, 43))))
+
+
     }
 
     @Test
@@ -185,11 +197,8 @@ class ClaimWorldServiceImplTest {
         // Given
         val world = mockk<World>()
         val location = Location(world, 48.5, 75.0, 32.3)
-        val defaultClaimArea = Area(
-            Position2D(location.blockX - 5, location.blockZ - 5),
-            Position2D(location.blockX + 5, location.blockZ + 5))
         every { location.block.type } returns Material.BELL
-        every { partitionService.isAreaValid(defaultClaimArea, location.world) } returns false
+        every { partitionService.isAreaValid(any(), location.world) } returns false
 
         // When
         val result = claimWorldService.create("New", location, playerThree)
@@ -204,11 +213,8 @@ class ClaimWorldServiceImplTest {
         // Given
         val world = mockk<World>()
         val location = Location(world, 48.5, 75.0, 32.3)
-        val defaultClaimArea = Area(
-            Position2D(location.blockX - 5, location.blockZ - 5),
-            Position2D(location.blockX + 5, location.blockZ + 5))
         every { location.block.type } returns Material.BELL
-        every { partitionService.isAreaValid(defaultClaimArea, location.world) } returns true
+        every { partitionService.isAreaValid(any(), location.world) } returns true
         every { playerLimitService.getRemainingClaimCount(playerThree) } returns 0
 
         // When
@@ -223,11 +229,8 @@ class ClaimWorldServiceImplTest {
         // Given
         val world = mockk<World>()
         val location = Location(world, 48.5, 75.0, 32.3)
-        val defaultClaimArea = Area(
-            Position2D(location.blockX - 5, location.blockZ - 5),
-            Position2D(location.blockX + 5, location.blockZ + 5))
         every { location.block.type } returns Material.BELL
-        every { partitionService.isAreaValid(defaultClaimArea, location.world) } returns true
+        every { partitionService.isAreaValid(any(), location.world) } returns true
         every { playerLimitService.getRemainingClaimCount(playerThree) } returns 0
 
         // When
@@ -242,11 +245,8 @@ class ClaimWorldServiceImplTest {
         // Given
         val world = mockk<World>()
         val location = Location(world, 48.5, 75.0, 32.3)
-        val defaultClaimArea = Area(
-            Position2D(location.blockX - 5, location.blockZ - 5),
-            Position2D(location.blockX + 5, location.blockZ + 5))
         every { location.block.type } returns Material.BELL
-        every { partitionService.isAreaValid(defaultClaimArea, location.world) } returns true
+        every { partitionService.isAreaValid(any(), location.world) } returns true
         every { playerLimitService.getRemainingClaimCount(playerThree) } returns 1
         every { playerLimitService.getRemainingClaimBlockCount(playerThree) } returns 12
 
@@ -262,11 +262,8 @@ class ClaimWorldServiceImplTest {
         // Given
         val world = mockk<World>()
         val location = Location(world, 48.5, 75.0, 32.3)
-        val defaultClaimArea = Area(
-            Position2D(location.blockX - 5, location.blockZ - 5),
-            Position2D(location.blockX + 5, location.blockZ + 5))
         every { location.block.type } returns Material.BELL
-        every { partitionService.isAreaValid(defaultClaimArea, location.world) } returns true
+        every { partitionService.isAreaValid(any(), location.world) } returns true
         every { playerLimitService.getRemainingClaimCount(playerThree) } returns 1
         every { playerLimitService.getRemainingClaimBlockCount(playerThree) } returns 121
         every { world.uid } returns UUID.randomUUID()

--- a/src/test/kotlin/dev/mizarc/bellclaims/infrastructure/services/PartitionServiceImplTest.kt
+++ b/src/test/kotlin/dev/mizarc/bellclaims/infrastructure/services/PartitionServiceImplTest.kt
@@ -44,6 +44,12 @@ class PartitionServiceImplTest {
     @BeforeEach
     fun setup() {
         config = mockk()
+        every { config.minimumPartitionSize } returns 3
+        every { config.distanceBetweenClaims } returns 1
+        every { config.initialClaimSize } returns 7
+        every { config.claimLimit } returns 3
+        every { config.claimBlockLimit } returns 50000
+
         partitionRepo = mockk()
         claimService = mockk()
         playerLimitService = mockk()


### PR DESCRIPTION
This allows administrators to change what these values should be server-wide.