### PR TITLE
Hotfixed issue of player state being returned as null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [0.3.1]
+
+### Fixed
+- Player state unable to be retrieved if the player somehow bypassed the login player state creation.
+- Other potential null-based issues based on invalid item, partition, or claim retrievals.
+
 ## [0.3.0]
 
 ### Added

--- a/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
@@ -126,9 +126,7 @@ class BellClaims : JavaPlugin() {
 
     private fun initialiseVaultDependency() {
         if (Bukkit.getPluginManager().getPlugin("Vault") != null) {
-            val serviceProvider: RegisteredServiceProvider<Chat> = server.servicesManager
-                .getRegistration(Chat::class.java)!!
-            metadata = serviceProvider.provider
+            server.servicesManager.getRegistration(Chat::class.java)?.let { metadata = it.provider }
             logger.info(Chat::class.java.toString())
         }
     }

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/partitions/Area.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/partitions/Area.kt
@@ -243,10 +243,7 @@ data class Area(var lowerPosition2D: Position2D, var upperPosition2D: Position2D
         var secondPosition: Position2D? = null
 
         fun build(): Area? {
-            if (secondPosition == null) {
-                return null
-            }
-            return Area(firstPosition, secondPosition!!)
+            return secondPosition?.let { Area(firstPosition, it) }
         }
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/persistence/partitions/PartitionRepositorySQLite.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/persistence/partitions/PartitionRepositorySQLite.kt
@@ -156,7 +156,7 @@ class PartitionRepositorySQLite(private val storage: Storage<Database>): Partiti
                     if (chunkPartitions[chunk] == null) {
                         chunkPartitions[chunk] = ArrayList()
                     }
-                    chunkPartitions[chunk]!!.add(partition.id)
+                    chunkPartitions[chunk]?.add(partition.id)
                 }
             }
         } catch (error: SQLException) {

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -267,7 +267,7 @@ class RuleBehaviour {
             if (event !is EntityExplodeEvent) return false
             if (event.entity !is Creeper) return false
             val blocks = getCreeperExplosionBlocks(
-                 event.blockList(), event.location.world!!, claimService, partitionService, flagService)
+                 event.blockList(), event.location.world, claimService, partitionService, flagService)
             event.blockList().removeAll(blocks)
             return true
         }
@@ -288,7 +288,7 @@ class RuleBehaviour {
             val blocks: List<Block>
             if (event is EntityExplodeEvent) {
                 if (event.entity is Creeper) return false
-                blocks = getExplosionBlocks(event.blockList(), event.location.world!!, claimService,
+                blocks = getExplosionBlocks(event.blockList(), event.location.world, claimService,
                     partitionService, flagService)
                 event.blockList().removeAll(blocks)
                 return true

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/commands/ClaimCommand.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/commands/ClaimCommand.kt
@@ -40,7 +40,7 @@ open class ClaimCommand : BaseCommand() {
      * @return True if the item exists in the inventory
      */
     fun isItemInInventory(inventory: PlayerInventory) : Boolean {
-        for (item in inventory.contents!!) {
+        for (item in inventory.contents) {
             if (item == null) continue
             if (item.itemMeta != null && item.itemMeta == getClaimTool().itemMeta) {
                 return true
@@ -72,7 +72,7 @@ open class ClaimCommand : BaseCommand() {
         }
 
         // Check if player owns claim
-        val claim = claimService.getById(partition.claimId)!!
+        val claim = claimService.getById(partition.claimId) ?: return false
         if (player.uniqueId != claim.owner.uniqueId) {
             player.sendMessage(getLangText("NoPermissionToModifyClaim"))
             return false

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/commands/InfoCommand.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/commands/InfoCommand.kt
@@ -18,8 +18,7 @@ class InfoCommand : ClaimCommand() {
     @CommandPermission("bellclaims.command.claim.info")
     fun onClaimInfo(player: Player) {
         val partition = getPartitionAtPlayer(player) ?: return
-
-        val claim = claimService.getById(partition.claimId)!!
+        val claim = claimService.getById(partition.claimId) ?: return
         val claimPartitions = partitionService.getByClaim(claim)
         val blockCount = claimService.getBlockCount(claim)
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/commands/PartitionsCommand.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/commands/PartitionsCommand.kt
@@ -14,10 +14,10 @@ class PartitionsCommand : ClaimCommand() {
     @CommandPermission("bellclaims.command.claim.partitions")
     fun onPartitions(player: Player, @Default("1") page: Int) {
         val partition = getPartitionAtPlayer(player) ?: return
+        val claim = claimService.getById(partition.claimId) ?: return
+        val claimPartitions = partitionService.getByClaim(claim).toList()
 
         // Check if page is empty
-        val claim = claimService.getById(partition.claimId)!!
-        val claimPartitions = partitionService.getByClaim(claim).toList()
         if (page * 10 - 9 > claimPartitions.count() || page < 1) {
             player.sendMessage("§cInvalid page specified.")
             return

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/commands/TrustListCommand.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/commands/TrustListCommand.kt
@@ -16,7 +16,7 @@ class TrustListCommand : ClaimCommand() {
     @CommandPermission("bellclaims.command.claim.trustlist")
     fun onTrustList(player: Player, @Default("1") page: Int) {
         val partition = getPartitionAtPlayer(player) ?: return
-        val claim = claimService.getById(partition.claimId)!!
+        val claim = claimService.getById(partition.claimId) ?: return
         val trustedPlayers = playerPermissionService.getByClaim(claim).toSortedMap(compareBy { it.uniqueId })
 
         // Check if claim has no trusted players

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimBellListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimBellListener.kt
@@ -38,7 +38,7 @@ class ClaimBellListener(private val claimService: ClaimService,
         }
 
         // Open the menu
-        val claimBuilder = Claim.Builder(event.player, event.clickedBlock!!.location)
+        val claimBuilder = Claim.Builder(event.player, clickedBlock.location)
         val claimManagementMenu = ClaimManagementMenu(claimService, claimWorldService, flagService, defaultPermissionService,
             playerPermissionService, playerLimitService, playerStateService, claimBuilder)
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimInteractListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimInteractListener.kt
@@ -95,10 +95,11 @@ class ClaimInteractListener(private var plugin: BellClaims,
         val claims = affectedClaims.distinct()
 
         // If player has override, do nothing
-        val playerState = playerStateService.getByPlayer(player)
-        if (playerState!!.claimOverride) {
-            return
+        val playerState = playerStateService.getByPlayer(player) ?: run {
+            playerStateService.registerPlayer(player)
+            playerStateService.getByPlayer(player)
         }
+        if (playerState?.claimOverride == true) return
 
         for (claim in claims) {
             // If player is owner, do nothing.

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolListener.kt
@@ -46,8 +46,9 @@ class EditToolListener(private val claims: ClaimRepository,
     @EventHandler
     fun onUseClaimTool(event: PlayerInteractEvent) {
         if (event.action != Action.RIGHT_CLICK_BLOCK) return
-        if (event.item == null) return
-        if (event.item!!.itemMeta != getClaimTool().itemMeta) return
+        val item = event.item ?: return
+        val clickedBlock = event.clickedBlock ?: return
+        if (item.itemMeta != getClaimTool().itemMeta) return
 
         // Open menu if in offhand
         if (event.hand == EquipmentSlot.OFF_HAND) {
@@ -63,24 +64,24 @@ class EditToolListener(private val claims: ClaimRepository,
         // Resizes an existing partition
         val partitionResizer = partitionResizers[event.player]
         if (partitionResizer != null) {
-            resizePartition(event.player, event.clickedBlock!!.location, partitionResizer)
+            resizePartition(event.player, clickedBlock.location, partitionResizer)
             return
         }
 
         // Creates a new partition
         val partitionBuilder = partitionBuilders[event.player]
         if (partitionBuilder != null) {
-            createPartition(event.player, event.clickedBlock!!.location, partitionBuilder)
+            createPartition(event.player, clickedBlock.location, partitionBuilder)
             return
         }
 
         // Select corner of existing claim
-        if (selectExistingCorner(event.player, event.clickedBlock!!.location)) {
+        if (selectExistingCorner(event.player, clickedBlock.location)) {
             return
         }
 
         // Selects a fresh location to start a new claim
-        selectNewCorner(event.player, event.clickedBlock!!.location)
+        selectNewCorner(event.player, clickedBlock.location)
     }
 
     @EventHandler
@@ -177,8 +178,7 @@ class EditToolListener(private val claims: ClaimRepository,
                         "claim blocks.")
                     .color(TextColor.color(255, 85, 85)))
             PartitionCreationResult.SUCCESS ->
-                player.sendActionBar(Component.text("New partition has been added to " +
-                        claims.getById(partition.claimId)!!.name)
+                player.sendActionBar(Component.text("New partition has been added to " + claim.name)
                     .color(TextColor.color(85, 255, 85)))
             PartitionCreationResult.NOT_CONNECTED -> player.sendActionBar(Component.text("That selection is " +
                     "not connected to your claim.")

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolRemovalListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolRemovalListener.kt
@@ -36,7 +36,7 @@ class EditToolRemovalListener : Listener {
 
         // Cancel if item meta doesn't exist
         val itemStack = event.cursor
-        val itemMeta = itemStack!!.itemMeta ?: return
+        val itemMeta = itemStack.itemMeta ?: return
 
         // Check if item is trying to be placed in top slot
         if (itemMeta == getClaimTool().itemMeta) {

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/ClaimManagementMenu.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/ClaimManagementMenu.kt
@@ -62,7 +62,7 @@ class ClaimManagementMenu(private val claimService: ClaimService,
                 .lore(getLangText("DeleteExistingClaim"))
             val guiIconEditorItem = GuiItem(iconEditorItem) { guiEvent -> guiEvent.isCancelled = true }
             pane.addItem(guiIconEditorItem, 4, 0)
-            gui.show(Bukkit.getPlayer(claimBuilder.player.uniqueId)!!)
+            Bukkit.getPlayer(claimBuilder.player.uniqueId)?.let { player -> gui.show(player)}
             return
         }
 
@@ -74,7 +74,7 @@ class ClaimManagementMenu(private val claimService: ClaimService,
                 .lore(getLangText("PlaceBellElsewhere"))
             val guiIconEditorItem = GuiItem(iconEditorItem) { guiEvent -> guiEvent.isCancelled = true }
             pane.addItem(guiIconEditorItem, 4, 0)
-            gui.show(Bukkit.getPlayer(claimBuilder.player.uniqueId)!!)
+            Bukkit.getPlayer(claimBuilder.player.uniqueId)?.let { player -> gui.show(player)}
             return
         }
 
@@ -85,7 +85,7 @@ class ClaimManagementMenu(private val claimService: ClaimService,
             .lore(getLangText("RemainingClaims1") + "${playerLimitService.getRemainingClaimCount(claimBuilder.player)} " + getLangText("RemainingClaims2"))
         val guiIconEditorItem = GuiItem(iconEditorItem) { openClaimNamingMenu() }
         pane.addItem(guiIconEditorItem, 4, 0)
-        gui.show(Bukkit.getPlayer(claimBuilder.player.uniqueId)!!)
+        Bukkit.getPlayer(claimBuilder.player.uniqueId)?.let { player -> gui.show(player)}
     }
 
     fun openClaimNamingMenu(existingName: Boolean = false) {
@@ -202,7 +202,7 @@ class ClaimManagementMenu(private val claimService: ClaimService,
     }
 
     private fun givePlayerTool(player: Player) {
-        for (item in player.inventory.contents!!) {
+        for (item in player.inventory.contents) {
             if (item == null) continue
             if (item.itemMeta != null && item.itemMeta == getClaimTool().itemMeta) {
                 return
@@ -212,7 +212,7 @@ class ClaimManagementMenu(private val claimService: ClaimService,
     }
 
     private fun givePlayerMoveTool(player: Player, claim: Claim) {
-        for (item in player.inventory.contents!!) {
+        for (item in player.inventory.contents) {
             if (item == null) continue
             if (item.itemMeta != null && item.itemMeta == getClaimMoveTool(claim).itemMeta) {
                 return
@@ -276,7 +276,7 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         }
         outputPane.addItem(confirmGuiItem, 0, 0)
         gui.outputComponent.addPane(outputPane)
-        gui.show(Bukkit.getPlayer(claimBuilder.player.uniqueId)!!)
+        Bukkit.getPlayer(claimBuilder.player.uniqueId)?.let { player -> gui.show(player)}
     }
 
     fun openClaimRenamingMenu(claim: Claim, existingName: Boolean = false) {
@@ -328,7 +328,7 @@ class ClaimManagementMenu(private val claimService: ClaimService,
         }
         thirdPane.addItem(confirmGuiItem, 0, 0)
         gui.resultComponent.addPane(thirdPane)
-        gui.show(Bukkit.getPlayer(claimBuilder.player.uniqueId)!!)
+        Bukkit.getPlayer(claimBuilder.player.uniqueId)?.let { player -> gui.show(player)}
     }
 
     fun openClaimFlagMenu(claim: Claim) {

--- a/src/main/kotlin/dev/mizarc/bellclaims/utils/ItemStackExtensions.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/utils/ItemStackExtensions.kt
@@ -18,14 +18,14 @@ fun ItemStack.amount(amount: Int): ItemStack {
 
 fun ItemStack.name(name: String): ItemStack {
     val meta = itemMeta
-    meta!!.setDisplayName(name)
+    meta.setDisplayName(name)
     itemMeta = meta
     return this
 }
 
 fun ItemStack.lore(text: String): ItemStack {
     val meta = itemMeta
-    var lore: MutableList<String>? = meta!!.lore
+    var lore: MutableList<String>? = meta.lore
     if (lore == null) {
         lore = ArrayList()
     }
@@ -72,7 +72,7 @@ fun ItemStack.type(material: Material): ItemStack {
 
 fun ItemStack.clearLore(): ItemStack {
     val meta = itemMeta
-    meta!!.lore = ArrayList()
+    meta.lore = ArrayList()
     itemMeta = meta
     return this
 }
@@ -99,7 +99,7 @@ fun ItemStack.color(color: Color): ItemStack {
 
 fun ItemStack.flag(vararg flag: ItemFlag): ItemStack {
     val meta = itemMeta
-    meta!!.addItemFlags(*flag)
+    meta.addItemFlags(*flag)
     itemMeta = meta
     return this
 }


### PR DESCRIPTION
An issue occurs where players are sometimes able to bypass the player registration process, causing their player state to be null. In instances like these, the player state is created when it needs to be used rather than trying to brute force it and returning null.

Various other null based issues have been solved, ranging from the getting of items, claims, and partitions that may return null.