### PR TITLE
Fixed bell duplication when move item is in inventory while breaking bell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ## [0.3.1]
 
 ### Fixed
+- Bell duplication when breaking a bell claim with a move item in your inventory.
 - Player state unable to be retrieved if the player somehow bypassed the login player state creation.
 - Other potential null-based issues based on invalid item, partition, or claim retrievals.
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimDestructionListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimDestructionListener.kt
@@ -12,6 +12,7 @@ import dev.mizarc.bellclaims.api.ClaimWorldService
 import dev.mizarc.bellclaims.api.PlayerStateService
 import dev.mizarc.bellclaims.domain.partitions.Position3D
 import dev.mizarc.bellclaims.utils.getStringMeta
+import org.bukkit.Material
 import org.bukkit.NamespacedKey
 import org.bukkit.block.Block
 import org.bukkit.block.BlockFace
@@ -25,6 +26,7 @@ import org.bukkit.event.block.TNTPrimeEvent
 import org.bukkit.event.entity.EntityExplodeEvent
 import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.event.world.StructureGrowEvent
+import org.bukkit.inventory.ItemStack
 import org.bukkit.persistence.PersistentDataType
 import java.util.UUID
 
@@ -61,14 +63,20 @@ class ClaimDestructionListener(val claimService: ClaimService,
 
         claimService.destroy(claim)
 
-        for (item in event.player.inventory) {
+        for ((index, item) in event.player.inventory.withIndex()) {
+            println(item)
             if (item == null) continue
             val itemMeta = item.itemMeta ?: continue
             val claimText = itemMeta.persistentDataContainer.get(
                 NamespacedKey("bellclaims","claim"), PersistentDataType.STRING) ?: continue
             val claimId = UUID.fromString(claimText) ?: continue
             if (claimId == claim.id) {
-                event.player.inventory.remove(item)
+                if (index == 40) {
+                    event.player.inventory.setItemInOffHand(ItemStack(Material.AIR))
+                }
+                else {
+                    event.player.inventory.remove(item)
+                }
             }
         }
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimDestructionListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimDestructionListener.kt
@@ -62,9 +62,11 @@ class ClaimDestructionListener(val claimService: ClaimService,
         claimService.destroy(claim)
 
         for (item in event.player.inventory) {
+            if (item == null) continue
             val itemMeta = item.itemMeta ?: continue
-            val claimId = UUID.fromString(itemMeta.persistentDataContainer.get(
-                NamespacedKey("bellclaims","claim"), PersistentDataType.STRING)) ?: continue
+            val claimText = itemMeta.persistentDataContainer.get(
+                NamespacedKey("bellclaims","claim"), PersistentDataType.STRING) ?: continue
+            val claimId = UUID.fromString(claimText) ?: continue
             if (claimId == claim.id) {
                 event.player.inventory.remove(item)
             }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimDestructionListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimDestructionListener.kt
@@ -11,6 +11,8 @@ import dev.mizarc.bellclaims.api.ClaimService
 import dev.mizarc.bellclaims.api.ClaimWorldService
 import dev.mizarc.bellclaims.api.PlayerStateService
 import dev.mizarc.bellclaims.domain.partitions.Position3D
+import dev.mizarc.bellclaims.utils.getStringMeta
+import org.bukkit.NamespacedKey
 import org.bukkit.block.Block
 import org.bukkit.block.BlockFace
 import org.bukkit.block.data.Bisected
@@ -23,6 +25,8 @@ import org.bukkit.event.block.TNTPrimeEvent
 import org.bukkit.event.entity.EntityExplodeEvent
 import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.event.world.StructureGrowEvent
+import org.bukkit.persistence.PersistentDataType
+import java.util.UUID
 
 class ClaimDestructionListener(val claimService: ClaimService,
                                private val claimWorldService: ClaimWorldService,
@@ -56,6 +60,16 @@ class ClaimDestructionListener(val claimService: ClaimService,
         }
 
         claimService.destroy(claim)
+
+        for (item in event.player.inventory) {
+            val itemMeta = item.itemMeta ?: continue
+            val claimId = UUID.fromString(itemMeta.persistentDataContainer.get(
+                NamespacedKey("bellclaims","claim"), PersistentDataType.STRING)) ?: continue
+            if (claimId == claim.id) {
+                event.player.inventory.remove(item)
+            }
+        }
+
         event.player.sendActionBar(
             Component.text("Claim '${claim.name}' has been destroyed")
             .color(TextColor.color(85, 255, 85)))


### PR DESCRIPTION
Straightforward issue, straightforward fix. All that needed to be done is to delete the specific bell in the inventory with the specific metadata associated with the bell when the bell block is broken.