### PR TITLE
Fixed inability to append partition on chunk border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [0.3.2]
+
+### Fixed
+- Inability to add a new partition when the partition to attach to is on a chunk border
+
 ## [0.3.1]
 
 ### Fixed

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/PartitionServiceImpl.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/PartitionServiceImpl.kt
@@ -308,8 +308,17 @@ class PartitionServiceImpl(private val config: Config,
     private fun getAdjacent(partition: Partition): ArrayList<Partition> {
         // Find all partitions within the chunks of the partition
         val claim = claimService.getById(partition.claimId) ?: return ArrayList()
+        val partitionChunks = partition.getChunks().toSet()
+
+        // Add chunk as well as surrounding chunks to get partitions on chunk edges
+        val chunks = mutableSetOf<Position2D>()
+        for (chunk in partitionChunks) {
+            chunks.add(chunk)
+            chunks.addAll(getSurroundingPositions(chunk, 1))
+        }
+
+        // Fetch all partitions
         val chunkPartitions = ArrayList<Partition>()
-        val chunks = partition.getChunks()
         for (chunk in chunks) {
             chunkPartitions.addAll(getByChunk(claim.worldId, chunk))
         }


### PR DESCRIPTION
This fixes the issue of not being able to append a new partition to a claim if the partition it is being attached to is on the edge of a chunk border. This is due to the function not grabbing adjacent chunks, leading to it not detecting the adjacent partition at all.