### PR TITLE
Added configurable visualiser delay period on claim tool unequip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [0.3.2]
 
+### Added
+- Configurable delay on visualiser hide to reduce lag on servers with high claim counts
+
 ### Fixed
 - Inability to add a new partition when the partition to attach to is on a chunk border
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
@@ -171,7 +171,7 @@ class BellClaims : JavaPlugin() {
      */
     private fun initialiseInteractions() {
         visualiser = Visualiser(this, claimService, partitionService, playerStateService,
-            visualisationService, scheduler)
+            visualisationService, config)
     }
 
     /**
@@ -223,7 +223,7 @@ class BellClaims : JavaPlugin() {
             EditToolListener(claimRepo, partitionService, playerLimitService, playerStateService, claimService,
                 visualiser, config), this)
         server.pluginManager.registerEvents(
-            EditToolVisualisingListener(this, playerStateService, visualiser), this)
+            EditToolVisualisingListener(this, playerStateService, visualiser, config), this)
         server.pluginManager.registerEvents(PlayerRegistrationListener(playerStateService), this)
         server.pluginManager.registerEvents(PlayerStateListener(playerStateService), this)
         server.pluginManager.registerEvents(EditToolRemovalListener(), this)
@@ -235,7 +235,7 @@ class BellClaims : JavaPlugin() {
         server.pluginManager.registerEvents(MoveToolRemovalListener(), this)
         server.pluginManager.registerEvents(
             Visualiser(this, claimService, partitionService,
-                playerStateService, visualisationService, scheduler), this)
+                playerStateService, visualisationService, config), this)
         server.pluginManager.registerEvents(
             PartitionUpdateListener(claimService, partitionService, playerStateService, visualiser), this)
         server.pluginManager.registerEvents(BlockLaunchListener(this), this)

--- a/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
@@ -3,33 +3,33 @@ package dev.mizarc.bellclaims
 import co.aikar.commands.PaperCommandManager
 import dev.mizarc.bellclaims.api.*
 import dev.mizarc.bellclaims.domain.claims.ClaimRepository
-import dev.mizarc.bellclaims.domain.permissions.ClaimPermissionRepository
 import dev.mizarc.bellclaims.domain.flags.ClaimFlagRepository
-import dev.mizarc.bellclaims.domain.permissions.PlayerAccessRepository
 import dev.mizarc.bellclaims.domain.partitions.PartitionRepository
+import dev.mizarc.bellclaims.domain.permissions.ClaimPermissionRepository
+import dev.mizarc.bellclaims.domain.permissions.PlayerAccessRepository
 import dev.mizarc.bellclaims.domain.players.PlayerStateRepository
-import net.milkbowl.vault.chat.Chat
-import org.bukkit.plugin.RegisteredServiceProvider
-import org.bukkit.plugin.java.JavaPlugin
 import dev.mizarc.bellclaims.infrastructure.persistence.Config
+import dev.mizarc.bellclaims.infrastructure.persistence.claims.ClaimFlagRepositorySQLite
+import dev.mizarc.bellclaims.infrastructure.persistence.claims.ClaimPermissionRepositorySQLite
 import dev.mizarc.bellclaims.infrastructure.persistence.claims.ClaimRepositorySQLite
+import dev.mizarc.bellclaims.infrastructure.persistence.claims.PlayerAccessRepositorySQLite
 import dev.mizarc.bellclaims.infrastructure.persistence.partitions.PartitionRepositorySQLite
 import dev.mizarc.bellclaims.infrastructure.persistence.players.PlayerStateRepositoryMemory
 import dev.mizarc.bellclaims.infrastructure.persistence.storage.SQLiteStorage
-import dev.mizarc.bellclaims.infrastructure.persistence.claims.ClaimFlagRepositorySQLite
-import dev.mizarc.bellclaims.infrastructure.persistence.claims.ClaimPermissionRepositorySQLite
-import dev.mizarc.bellclaims.infrastructure.persistence.claims.PlayerAccessRepositorySQLite
 import dev.mizarc.bellclaims.infrastructure.services.*
 import dev.mizarc.bellclaims.infrastructure.services.playerlimit.SimplePlayerLimitServiceImpl
 import dev.mizarc.bellclaims.infrastructure.services.playerlimit.VaultPlayerLimitServiceImpl
 import dev.mizarc.bellclaims.interaction.commands.*
 import dev.mizarc.bellclaims.interaction.listeners.*
 import dev.mizarc.bellclaims.interaction.visualisation.Visualiser
+import net.milkbowl.vault.chat.Chat
 import org.bukkit.Bukkit
-
 import org.bukkit.configuration.file.FileConfiguration
 import org.bukkit.configuration.file.YamlConfiguration
+import org.bukkit.plugin.java.JavaPlugin
+import org.bukkit.scheduler.BukkitScheduler
 import java.io.File
+
 
 /**
  * The entry point for the Bell Claims plugin.
@@ -39,6 +39,7 @@ class BellClaims : JavaPlugin() {
     private lateinit var metadata: Chat
     internal var config: Config = Config(this)
     val storage = SQLiteStorage(this)
+    private lateinit var scheduler: BukkitScheduler
 
     private lateinit var claimRepo: ClaimRepository
     private lateinit var partitionRepo: PartitionRepository
@@ -66,6 +67,8 @@ class BellClaims : JavaPlugin() {
     private lateinit var langFile: File
 
     override fun onEnable() {
+        scheduler = server.scheduler
+
         initialiseVaultDependency()
         initialiseRepositories()
         initialiseServices()
@@ -167,7 +170,8 @@ class BellClaims : JavaPlugin() {
      * Initialises all special interactions.
      */
     private fun initialiseInteractions() {
-        visualiser = Visualiser(this, claimService, partitionService, playerStateService, visualisationService)
+        visualiser = Visualiser(this, claimService, partitionService, playerStateService,
+            visualisationService, scheduler)
     }
 
     /**
@@ -231,7 +235,7 @@ class BellClaims : JavaPlugin() {
         server.pluginManager.registerEvents(MoveToolRemovalListener(), this)
         server.pluginManager.registerEvents(
             Visualiser(this, claimService, partitionService,
-                playerStateService, visualisationService), this)
+                playerStateService, visualisationService, scheduler), this)
         server.pluginManager.registerEvents(
             PartitionUpdateListener(claimService, partitionService, playerStateService, visualiser), this)
         server.pluginManager.registerEvents(BlockLaunchListener(this), this)

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/players/PlayerState.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/players/PlayerState.kt
@@ -5,6 +5,7 @@ import org.bukkit.OfflinePlayer
 import org.bukkit.entity.Player
 import dev.mizarc.bellclaims.domain.claims.Claim
 import dev.mizarc.bellclaims.domain.partitions.Position3D
+import org.bukkit.scheduler.BukkitRunnable
 
 /**
  * Holds temporary player state data mainly pertaining to claim editing.
@@ -18,6 +19,7 @@ class PlayerState(val player: OfflinePlayer) {
     var isVisualisingClaims = false
     var visualisedBlockPositions: MutableMap<Claim, Set<Position3D>> = mutableMapOf()
     var isInClaimMenu: Claim? = null
+    var scheduledVisualiserHide: BukkitRunnable? = null
 
     /**
      * Gets the online version of the player instance.

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/persistence/Config.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/persistence/Config.kt
@@ -11,6 +11,7 @@ class Config(val plugin: Plugin) {
     var initialClaimSize = 0
     var minimumPartitionSize = 0
     var distanceBetweenClaims = 0
+    var visualiserDelayPeriod = 0
     var pluginLanguage = "EN"
 
     init {
@@ -24,11 +25,11 @@ class Config(val plugin: Plugin) {
         initialClaimSize = maxOf(3,configFile.getInt("initial_claim_size"))
         minimumPartitionSize = maxOf(3, configFile.getInt("minimum_partition_size"))
         distanceBetweenClaims = configFile.getInt("distance_between_claims")
+        visualiserDelayPeriod = configFile.getInt("visualiser_delay_period")
         pluginLanguage = configFile.getString("plugin_language") ?: "EN"
     }
 
     private fun createDefaultConfig() {
-
         val configFile = File(plugin.dataFolder, "config.yml")
         if (!configFile.exists()) {
             plugin.saveResource("config.yml", false)

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolVisualisingListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolVisualisingListener.kt
@@ -3,6 +3,7 @@ package dev.mizarc.bellclaims.interaction.listeners
 import dev.mizarc.bellclaims.api.PlayerStateService
 import dev.mizarc.bellclaims.domain.partitions.Position3D
 import dev.mizarc.bellclaims.infrastructure.getClaimTool
+import dev.mizarc.bellclaims.infrastructure.persistence.Config
 import dev.mizarc.bellclaims.interaction.visualisation.Visualiser
 import org.bukkit.entity.EntityType
 import org.bukkit.entity.Player
@@ -18,7 +19,8 @@ import kotlin.concurrent.thread
 
 class EditToolVisualisingListener(private val plugin: JavaPlugin,
                                   private val playerStateService: PlayerStateService,
-                                  private val visualiser: Visualiser): Listener {
+                                  private val visualiser: Visualiser,
+                                  private val config: Config): Listener {
     @EventHandler
     fun onHoldClaimTool(event: PlayerItemHeldEvent) {
         plugin.server.scheduler.runTask(plugin, Runnable { autoClaimToolVisualisation(event.player) })
@@ -67,8 +69,24 @@ class EditToolVisualisingListener(private val plugin: JavaPlugin,
         // Visualise if player isn't already holding the claim tool (e.g. swapping hands)
         val holdingClaimTool = (mainItemMeta == getClaimTool().itemMeta) || (offhandItemMeta == getClaimTool().itemMeta)
         if (!holdingClaimTool || !playerState.isHoldingClaimTool) {
-            visualiser.hide(player)
-            if (holdingClaimTool) visualiser.show(player)
+            if (config.visualiserDelayPeriod > 0) {
+                if (holdingClaimTool) {
+                    val scheduledVisualiserHide = playerState.scheduledVisualiserHide
+                    if (scheduledVisualiserHide != null && !scheduledVisualiserHide.isCancelled) {
+                        scheduledVisualiserHide.cancel()
+                        playerState.scheduledVisualiserHide = null
+                    } else {
+                        visualiser.show(player)
+                    }
+
+                } else {
+                    visualiser.delayedVisualiserHide(player)
+                }
+            }
+            else {
+                visualiser.hide(player)
+                if (holdingClaimTool) visualiser.show(player)
+            }
         }
         playerState.isHoldingClaimTool = holdingClaimTool
     }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolVisualisingListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolVisualisingListener.kt
@@ -2,6 +2,7 @@ package dev.mizarc.bellclaims.interaction.listeners
 
 import dev.mizarc.bellclaims.api.PlayerStateService
 import dev.mizarc.bellclaims.domain.partitions.Position3D
+import dev.mizarc.bellclaims.domain.players.PlayerState
 import dev.mizarc.bellclaims.infrastructure.getClaimTool
 import dev.mizarc.bellclaims.infrastructure.persistence.Config
 import dev.mizarc.bellclaims.interaction.visualisation.Visualiser
@@ -70,18 +71,7 @@ class EditToolVisualisingListener(private val plugin: JavaPlugin,
         val holdingClaimTool = (mainItemMeta == getClaimTool().itemMeta) || (offhandItemMeta == getClaimTool().itemMeta)
         if (!holdingClaimTool || !playerState.isHoldingClaimTool) {
             if (config.visualiserDelayPeriod > 0) {
-                if (holdingClaimTool) {
-                    val scheduledVisualiserHide = playerState.scheduledVisualiserHide
-                    if (scheduledVisualiserHide != null && !scheduledVisualiserHide.isCancelled) {
-                        scheduledVisualiserHide.cancel()
-                        playerState.scheduledVisualiserHide = null
-                    } else {
-                        visualiser.show(player)
-                    }
-
-                } else {
-                    visualiser.delayedVisualiserHide(player)
-                }
+                runDelayedVisualisation(holdingClaimTool, playerState, player)
             }
             else {
                 visualiser.hide(player)
@@ -89,5 +79,20 @@ class EditToolVisualisingListener(private val plugin: JavaPlugin,
             }
         }
         playerState.isHoldingClaimTool = holdingClaimTool
+    }
+
+    private fun runDelayedVisualisation(holdingClaimTool: Boolean, playerState: PlayerState, player: Player) {
+        if (holdingClaimTool) {
+            val scheduledVisualiserHide = playerState.scheduledVisualiserHide
+            if (scheduledVisualiserHide != null && !scheduledVisualiserHide.isCancelled) {
+                scheduledVisualiserHide.cancel()
+                playerState.scheduledVisualiserHide = null
+            } else {
+                visualiser.show(player)
+            }
+
+        } else {
+            visualiser.delayedVisualiserHide(player)
+        }
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/visualisation/Visualiser.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/visualisation/Visualiser.kt
@@ -6,19 +6,15 @@ import dev.mizarc.bellclaims.api.PlayerStateService
 import dev.mizarc.bellclaims.api.VisualisationService
 import dev.mizarc.bellclaims.domain.claims.Claim
 import dev.mizarc.bellclaims.domain.partitions.Position3D
+import dev.mizarc.bellclaims.infrastructure.persistence.Config
 import dev.mizarc.bellclaims.utils.carpetBlocks
-import org.bukkit.Bukkit
 import org.bukkit.Chunk
 import org.bukkit.Location
 import org.bukkit.Material
-import org.bukkit.entity.LivingEntity
 import org.bukkit.entity.Player
 import org.bukkit.event.Listener
 import org.bukkit.plugin.java.JavaPlugin
-import org.bukkit.potion.PotionEffect
-import org.bukkit.potion.PotionEffectType
 import org.bukkit.scheduler.BukkitRunnable
-import org.bukkit.scheduler.BukkitScheduler
 
 
 class Visualiser(private val plugin: JavaPlugin,
@@ -26,7 +22,7 @@ class Visualiser(private val plugin: JavaPlugin,
                  private val partitionService: PartitionService,
                  private val playerStateService: PlayerStateService,
                  private val visualisationService: VisualisationService,
-                 private val scheduler: BukkitScheduler) : Listener {
+                 private val config: Config) : Listener {
     /**
      * Display claim visualisation to target player
      */
@@ -87,12 +83,13 @@ class Visualiser(private val plugin: JavaPlugin,
         class VisualiserHideRunnable : BukkitRunnable() {
             override fun run() {
                 hide(player)
+                cancel()
             }
         }
 
         playerState.scheduledVisualiserHide = VisualiserHideRunnable()
         val scheduledVisualiserHide = playerState.scheduledVisualiserHide
-        scheduledVisualiserHide?.runTaskLater(plugin, 20)
+        scheduledVisualiserHide?.runTaskLater(plugin, (20 * config.visualiserDelayPeriod).toLong())
     }
 
     /**

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,6 +3,7 @@ claim_block_limit: 5000
 initial_claim_size: 7 # Minimum value of 3
 minimum_partition_size: 3 # Minimum value of 3
 distance_between_claims: 1
+visualiser_delay_period: 2
 plugin_language: EN
 
 #NOT COMPLETED


### PR DESCRIPTION
This resolves potential lag when a player decides to rapidly equip and unequip the claim tool, which causes the visualiser to recalculate itself every single time it is triggered. A value can be modified in the config to set how long the visualiser remains before being hidden.