### PR TITLE
Added protection against pot breakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [0.3.3]
 
+### Added
+- Protection against players breaking pots with projectiles. Requires the build permission.
+- Protection against mobs breaking pots with projectiles. Bypassed by the mob griefing flag.
+
 ### Fixed
 - Tools being placed in pots which can be used to duplicate these items
 - Residual comments spamming the console

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
@@ -29,7 +29,8 @@ enum class Flag(val rules: Array<RuleExecutor>) {
         RuleBehaviour.mobDamageStaticEntity,
         RuleBehaviour.creeperExplode,
         RuleBehaviour.creeperDamageStaticEntity,
-        RuleBehaviour.creeperDamageHangingEntity
+        RuleBehaviour.creeperDamageHangingEntity,
+        RuleBehaviour.potBreak
     )),
 
     /**

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
@@ -26,7 +26,8 @@ enum class ClaimPermission(val events: Array<PermissionExecutor>) {
         PermissionBehaviour.mountFarmlandStep,
         PermissionBehaviour.dragonEggTeleport,
         PermissionBehaviour.bucketFill,
-        PermissionBehaviour.pumpkinShear
+        PermissionBehaviour.pumpkinShear,
+        PermissionBehaviour.potBreak
     )),
 
     /**

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -17,6 +17,7 @@ import dev.mizarc.bellclaims.domain.flags.Flag
 import org.bukkit.Location
 import org.bukkit.block.BlockState
 import org.bukkit.block.data.Directional
+import org.bukkit.block.data.type.DecoratedPot
 import org.bukkit.entity.*
 import org.bukkit.event.entity.AreaEffectCloudApplyEvent
 import org.bukkit.event.entity.EntityBreakDoorEvent
@@ -98,6 +99,8 @@ class RuleBehaviour {
         val lightningDamage = RuleExecutor(LightningStrikeEvent::class.java, Companion::cancelLightningStrikeEvent,
             Companion::lightningStrikeInClaim)
         val blockFall = RuleExecutor(EntityChangeBlockEvent::class.java, Companion::cancelBlockFall,
+            Companion::entityChangeBlockInClaim)
+        val potBreak = RuleExecutor(EntityChangeBlockEvent::class.java, Companion::cancelProjectilePotBreak,
             Companion::entityChangeBlockInClaim)
 
         /**
@@ -276,6 +279,15 @@ class RuleBehaviour {
                                             partitionService: PartitionService, flagService: FlagService): Boolean {
             if (event !is EntityChangeBlockEvent) return false
             if (event.entity !is Monster) return false
+            event.isCancelled = true
+            return true
+        }
+
+        private fun cancelProjectilePotBreak(event: Event, claimService: ClaimService,
+                                             partitionService: PartitionService, flagService: FlagService): Boolean {
+            if (event !is EntityChangeBlockEvent) return false
+            if (event.entity is Player) return false
+            if (event.block.blockData !is DecoratedPot) return false
             event.isCancelled = true
             return true
         }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/PermissionBehaviour.kt
@@ -11,6 +11,7 @@ import org.bukkit.block.data.AnaloguePowerable
 import org.bukkit.block.data.Openable
 import org.bukkit.block.data.Powerable
 import org.bukkit.block.data.type.Bed
+import org.bukkit.block.data.type.DecoratedPot
 import org.bukkit.block.data.type.Farmland
 import org.bukkit.block.data.type.RespawnAnchor
 import org.bukkit.block.data.type.Sign
@@ -22,6 +23,7 @@ import org.bukkit.event.Event
 import org.bukkit.event.Listener
 import org.bukkit.event.block.*
 import org.bukkit.event.entity.AreaEffectCloudApplyEvent
+import org.bukkit.event.entity.EntityChangeBlockEvent
 import org.bukkit.event.entity.EntityDamageByEntityEvent
 import org.bukkit.event.entity.EntityInteractEvent
 import org.bukkit.event.entity.EntityPlaceEvent
@@ -245,6 +247,10 @@ class PermissionBehaviour {
         // Used to prevent players from setting spawn in bed or respawn anchors
         val respawnSet = PermissionExecutor(PlayerSetSpawnEvent::class.java, Companion::cancelSetSpawnEvent,
             Companion::getPlayerSetSpawnLocations, Companion::getPlayerSetSpawnPlayer)
+
+        // Used to prevent players from breaking pots with projectiles
+        val potBreak = PermissionExecutor(EntityChangeBlockEvent::class.java, Companion::cancelProjectilePotBreak,
+            Companion::getEntityChangeBlockLocations, Companion::getEntityChangeBlockPlayer)
 
         /**
          * Cancels any cancellable event.
@@ -651,6 +657,16 @@ class PermissionBehaviour {
         }
 
         /**
+         * Cancels the action of breaking a pot with a projectile.
+         */
+        private fun cancelProjectilePotBreak(listener: Listener, event: Event): Boolean {
+            if (event !is EntityChangeBlockEvent) return false
+            if (event.block.blockData !is DecoratedPot) return false
+            event.isCancelled = true
+            return true
+        }
+
+        /**
          * Gets the affected locations of the VehicleDestroyEvent.
          */
         private fun getVehicleDestroyLocations(event: Event): List<Location> {
@@ -869,6 +885,11 @@ class PermissionBehaviour {
             if (event !is PlayerSetSpawnEvent) return listOf()
             val location = event.location ?: return listOf()
             return listOf(location)
+        }
+
+        private fun getEntityChangeBlockLocations(event: Event): List<Location> {
+            if (event !is EntityChangeBlockEvent) return listOf()
+            return listOf(event.block.location)
         }
 
         /**
@@ -1119,6 +1140,19 @@ class PermissionBehaviour {
         private fun getPlayerSetSpawnPlayer(event: Event): Player? {
             if (event !is PlayerSetSpawnEvent) return null
             return event.player
+        }
+
+        /**
+         * Gets the player that is triggering the EntityChangeBlockEvent.
+         */
+        private fun getEntityChangeBlockPlayer(event: Event): Player? {
+            if (event !is EntityChangeBlockEvent) return null
+            if (event.entity is Player) return event.entity as Player
+            if (event.entity is Projectile) {
+                val projectile = event.entity as Projectile
+                if (projectile.shooter is Player) return projectile.shooter as Player
+            }
+            return null
         }
     }
 }


### PR DESCRIPTION
This protects against pot breakage by players that is protected by the build permission, and against mobs that is protected by the mob griefing flag.