### PR TITLE
Fixed visualiser triggering hide delay while not currently visualising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,18 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Protection against mobs breaking pots with projectiles. Bypassed by the mob griefing flag.
 
 ### Fixed
-- Tools being placed in pots which can be used to duplicate these items
-- Residual comments spamming the console
+- Tools being placed in pots which can be used to duplicate these items.
+- Visualiser delay triggering when the visualiser is not currently being shown.
+- Residual comments spamming the console.
 
 ## [0.3.2]
 
 ### Added
-- Configurable delay on visualiser hide time to stop lag abuse
-- Configurable allowed refresh period for visualiser refreshes to stop lag abuse
+- Configurable delay on visualiser hide time to stop lag abuse.
+- Configurable allowed refresh period for visualiser refreshes to stop lag abuse.
 
 ### Fixed
-- Inability to add a new partition when the partition to attach to is on a chunk border
+- Inability to add a new partition when the partition to attach to is on a chunk border.
 
 ## [0.3.1]
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolVisualisingListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolVisualisingListener.kt
@@ -12,6 +12,7 @@ import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.entity.EntityPickupItemEvent
 import org.bukkit.event.inventory.InventoryClickEvent
+import org.bukkit.event.inventory.InventoryEvent
 import org.bukkit.event.player.PlayerDropItemEvent
 import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.event.player.PlayerItemHeldEvent
@@ -91,7 +92,7 @@ class EditToolVisualisingListener(private val plugin: JavaPlugin,
                 visualiser.show(player)
             }
 
-        } else {
+        } else if (playerState.isVisualisingClaims) {
             visualiser.delayedVisualiserHide(player)
         }
     }


### PR DESCRIPTION
This creates an issue where it activates the delay timer when there's
nothing being visualised, making the visualiser not show up until the
claim tool is unequipped for a set amount of time.