### PR TITLE
Added protection against using pots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ### Added
 - Protection against players breaking pots with projectiles. Requires the build permission.
 - Protection against mobs breaking pots with projectiles. Bypassed by the mob griefing flag.
+- Protection against putting items in pots. Requires the manipulate permission.
 
 ### Fixed
 - Tools being placed in pots which can be used to duplicate these items.

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/PermissionBehaviour.kt
@@ -360,7 +360,8 @@ class PermissionBehaviour {
                 block.type != Material.WATER_CAULDRON &&
                 block.type != Material.LAVA_CAULDRON &&
                 block.type != Material.POWDER_SNOW_CAULDRON &&
-                block.type != Material.CAKE) return false
+                block.type != Material.CAKE &&
+                block.type != Material.DECORATED_POT) return false
             event.isCancelled = true
             return true
         }


### PR DESCRIPTION
This stops people from being able to put items in pots, which you can grant permission for using the manipulate permission.