### PR TITLE
Fixed visualiser not displaying inner border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [0.3.4]
+
+### Fixed
+- No visible inner border visualisation when set to view mode on claims that are donut shaped.
+
 ## [0.3.3]
 
 ### Added


### PR DESCRIPTION
If someone makes a claim in a donut shape leaving a middle section unclaimed, the visualiser does not show this and players could easily mistake that area as being claimed. This renders all inner borders in a similar manner to the outer border.

It may be useful to make the inner border a different colour in a more complex implementation, but API changes may need to be done to accommodate this. I will leave it as is for the patch fix.