### PR TITLE
Fixed trident dupe and various other potential item interaction issues on bell usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 - No visible inner border visualisation when set to view mode on claims that are donut shaped.
+- Using bell while holding an item causing the item to be used, resulting in major issues like trident duplication.
 
 ## [0.3.3]
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimBellListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimBellListener.kt
@@ -38,6 +38,7 @@ class ClaimBellListener(private val claimService: ClaimService,
         }
 
         // Open the menu
+        event.isCancelled = true
         val claimBuilder = Claim.Builder(event.player, clickedBlock.location)
         val claimManagementMenu = ClaimManagementMenu(claimService, claimWorldService, flagService, defaultPermissionService,
             playerPermissionService, playerLimitService, playerStateService, claimBuilder)


### PR DESCRIPTION
All this does is cancel the interact event when the bell is being shift right click. This most importantly solves the trident duplication issue, but also makes it less annoying to interact with a bell when an item is being held in hand as it will use the item when the player is just trying to open the bell menu.