### PR TITLE
Fixed flag bypasses when actions done in adjacent claims affect another

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ## [0.3.4]
 
 ### Fixed
-- No visible inner border visualisation when set to view mode on claims that are donut shaped.
+- No visible inner border visualisation when set to view mode on claims that aren't completely filled in.
 - Using bell while holding an item causing the item to be used, resulting in major issues like trident duplication.
+- Claim flags bypassed when an action is being done in one claim that would have an effect in another.
 
 ## [0.3.3]
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "dev.mizarc"
-version = "0.3.3"
+version = "0.3.4"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -459,8 +459,11 @@ class RuleBehaviour {
         private fun cancelFluidFlow(event: Event, claimService: ClaimService,
                                     partitionService: PartitionService, flagService: FlagService): Boolean {
             if (event !is BlockFromToEvent) return false
-            if (partitionService.getByLocation(event.block.location) != null) return false
-            if (partitionService.getByLocation(event.toBlock.location) == null) return false
+            val sourceClaim = partitionService.getByLocation(event.block.location)?.
+                let { claimService.getById(it.claimId) }
+            val moveClaim = partitionService.getByLocation(event.toBlock.location)?.
+                let { claimService.getById(it.claimId) }
+            if (sourceClaim == moveClaim) return false
             event.isCancelled = true
             return true
         }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -572,11 +572,7 @@ class RuleBehaviour {
                 val partition = partitionService.getByLocation(event.block.location)
                 val sourcePartition = partitionService.getByLocation(event.source.location)
 
-                if (sourcePartition == partition) {
-                    return false
-                }
-
-                if (sourcePartition == null) {
+                if (sourcePartition != partition) {
                     event.isCancelled = true
                     return true
                 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -496,7 +496,7 @@ class RuleBehaviour {
                 return true
             }
 
-            // Check the blocks that the piston is pushinga
+            // Check the blocks that the piston is pushing
             var blockInClaim = false
             for (block in event.blocks) {
                 val newBlockPosition = block.location.clone()
@@ -603,12 +603,13 @@ class RuleBehaviour {
         private fun cancelSpongeAbsorbEvent(event: Event, claimService: ClaimService,
                                             partitionService: PartitionService, flagService: FlagService): Boolean {
             if (event !is SpongeAbsorbEvent) return false
-            if (partitionService.getByLocation(event.block.location) != null) return false
+            val spongeClaim = partitionService.getByLocation(event.block.location)?.let { claimService.getById(it.claimId) }
             val cancelledBlocks: MutableList<BlockState> = mutableListOf()
             for (block in event.blocks) {
                 val partition = partitionService.getByLocation(block.location) ?: continue
                 val claim = claimService.getById(partition.claimId) ?: continue
-                if (!flagService.doesClaimHaveFlag(claim, Flag.Explosions)) {
+                if (spongeClaim == claim) continue
+                if (!flagService.doesClaimHaveFlag(claim, Flag.Sponge)) {
                     cancelledBlocks.add(block)
                 }
             }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: BellClaims
-version: 0.3.3
+version: 0.3.4
 api-version: '1.21'
 main: dev.mizarc.bellclaims.BellClaims
 softdepend: [Vault]


### PR DESCRIPTION
This issue is present in flags such as pistons or sculk spread, where if someone places the source block in one claim, it can have an effect in the other claim. The existing checks only take into account changes done outside of any claim affecting areas inside of a claim, not changes that could be done using an adjacent claim.