### PR TITLE
Added protection against fluids forming blocks in claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [0.3.5]
+
+### Fixed
+- Water placed on the edge of a claim turning concrete powder into concrete and lava into obsidian.
+
 ## [0.3.4]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ## [0.3.5]
 
 ### Fixed
-- Water placed on the edge of a claim turning concrete powder into concrete and lava into obsidian.
+- Water placed on the edge of a claim turning concrete powder into concrete and lava into obsidian. Bypassed by the fluid flow flag.
 
 ## [0.3.4]
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
@@ -57,7 +57,8 @@ enum class Flag(val rules: Array<RuleExecutor>) {
      * When fluids flow into a claim
      */
     Fluids(arrayOf(
-        RuleBehaviour.fluidFlow
+        RuleBehaviour.fluidFlow,
+        RuleBehaviour.fluidBlockForm
     )),
 
     Trees(arrayOf(

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -750,8 +750,8 @@ class RuleBehaviour {
             val directions = setOf(Position2D(1, 0), Position2D(-1, 0),
                 Position2D(0, 1), Position2D(0, -1))
 
-            // Concrete protection
-            if (event.block.type in MaterialTags.CONCRETE_POWDER.values) {
+            // Concrete & lavaprotection
+            if (event.block.type in MaterialTags.CONCRETE_POWDER.values || event.block.type == Material.LAVA) {
                 for (direction in directions) {
                     // Check if adjacent block is water
                     val checkPosition = Position3D(formPosition.x + direction.x, formPosition.y,
@@ -759,7 +759,7 @@ class RuleBehaviour {
                     val checkBlock = event.block.world.getBlockAt(checkPosition.x, checkPosition.y, checkPosition.z)
                     if (checkBlock.type != Material.WATER) continue
 
-                    // Check if water is in same claim as concrete powder
+                    // Check if water is in same claim as the block it is forming
                     val checkClaim = partitionService.getByLocation(checkPosition.toLocation(event.block.world))?.
                         let { claimService.getById(it.claimId) }
                     if (formClaim == checkClaim) return false


### PR DESCRIPTION
This affects concrete powder and lava as far as I'm aware. If fluids are placed outside of the current claim and flows into lava or concrete powder at the edge of a claim, it turns it into a different block. This is protected by the fluid flow flag.