### PR TITLE
Fixed crash occuring when visualiser is trying to render certain partition configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [0.3.5]
+
+### Fixed
+- Server crashing due to math error when certain claim partition configurations are attempting to be visualised.
+
 ## [0.3.4]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Added
 - Protecction against water placed on the edge of a claim turning concrete powder into concrete and lava into obsidian. Bypassed by the fluid flow flag.
-- 
+
 ### Fixed
 - Server crashing due to math error when certain claim partition configurations are attempting to be visualised.
 


### PR DESCRIPTION
Due to a certain math issue, some claims fail to be visualised, sending the function on an infinite loop that eventually crashes the server. This reworks the way the inner borders are calculated so that they are all obtained on the same function run, rather than being done on independent function runs that are likely to cause issues if done incorrectly.