### PR TITLE
Added protection against wind charges pushing things around

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [0.3.6]
+
+### Added
+- Protection against wind charges being used to push animals and villagers, protected by the husbandry permission.
+- Protection against wind charges being used to push armour stands. Requires the build permission.
+
 ## [0.3.5]
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "dev.mizarc"
-version = "0.3.5"
+version = "0.3.6"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
@@ -90,7 +90,8 @@ enum class ClaimPermission(val events: Array<PermissionExecutor>) {
         PermissionBehaviour.beehiveBottle,
         PermissionBehaviour.tridentLightningDamage,
         PermissionBehaviour.potionSplash,
-        PermissionBehaviour.potionLinger
+        PermissionBehaviour.potionLinger,
+        PermissionBehaviour.animalPush
     )),
 
     /**

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
@@ -27,7 +27,8 @@ enum class ClaimPermission(val events: Array<PermissionExecutor>) {
         PermissionBehaviour.dragonEggTeleport,
         PermissionBehaviour.bucketFill,
         PermissionBehaviour.pumpkinShear,
-        PermissionBehaviour.potBreak
+        PermissionBehaviour.potBreak,
+        PermissionBehaviour.armourStandPush
     )),
 
     /**

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/PermissionBehaviour.kt
@@ -1,5 +1,6 @@
 package dev.mizarc.bellclaims.interaction.behaviours
 
+import com.destroystokyo.paper.event.entity.EntityKnockbackByEntityEvent
 import com.destroystokyo.paper.event.player.PlayerSetSpawnEvent
 import io.papermc.paper.event.block.PlayerShearBlockEvent
 import io.papermc.paper.event.player.PlayerFlowerPotManipulateEvent
@@ -251,6 +252,11 @@ class PermissionBehaviour {
         // Used to prevent players from breaking pots with projectiles
         val potBreak = PermissionExecutor(EntityChangeBlockEvent::class.java, Companion::cancelProjectilePotBreak,
             Companion::getEntityChangeBlockLocations, Companion::getEntityChangeBlockPlayer)
+
+        // Used to prevent wind charges from affecting armour stands
+        val armourStandPush = PermissionExecutor(EntityKnockbackByEntityEvent::class.java,
+            Companion::cancelArmourStandPush, Companion::getEntityKnockbackByEntityLocations,
+            Companion::getEntityKnockbackByEntityPlayer)
 
         /**
          * Cancels any cancellable event.
@@ -668,6 +674,16 @@ class PermissionBehaviour {
         }
 
         /**
+         * Cancels the action of breaking a pot with a projectile.
+         */
+        private fun cancelArmourStandPush(listener: Listener, event: Event): Boolean {
+            if (event !is EntityKnockbackByEntityEvent) return false
+            if (event.entity !is ArmorStand) return false
+            event.isCancelled = true
+            return true
+        }
+
+        /**
          * Gets the affected locations of the VehicleDestroyEvent.
          */
         private fun getVehicleDestroyLocations(event: Event): List<Location> {
@@ -888,9 +904,20 @@ class PermissionBehaviour {
             return listOf(location)
         }
 
+        /**
+         * Gets the affected locations of the EntityChangeBlockEvent.
+         */
         private fun getEntityChangeBlockLocations(event: Event): List<Location> {
             if (event !is EntityChangeBlockEvent) return listOf()
             return listOf(event.block.location)
+        }
+
+        /**
+         * Gets the affected locations of the EntityKnockbackByEntityEvent.
+         */
+        private fun getEntityKnockbackByEntityLocations(event: Event): List<Location> {
+            if (event !is EntityKnockbackByEntityEvent) return listOf()
+            return listOf(event.entity.location)
         }
 
         /**
@@ -1151,6 +1178,19 @@ class PermissionBehaviour {
             if (event.entity is Player) return event.entity as Player
             if (event.entity is Projectile) {
                 val projectile = event.entity as Projectile
+                if (projectile.shooter is Player) return projectile.shooter as Player
+            }
+            return null
+        }
+
+        /**
+         * Gets the player that is triggering the EntityKnockbackByEntityEvent.
+         */
+        private fun getEntityKnockbackByEntityPlayer(event: Event): Player? {
+            if (event !is EntityKnockbackByEntityEvent) return null
+            if (event.hitBy is Player) return event.hitBy as Player
+            if (event.hitBy is Projectile) {
+                val projectile = event.hitBy as Projectile
                 if (projectile.shooter is Player) return projectile.shooter as Player
             }
             return null

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/PermissionBehaviour.kt
@@ -258,6 +258,11 @@ class PermissionBehaviour {
             Companion::cancelArmourStandPush, Companion::getEntityKnockbackByEntityLocations,
             Companion::getEntityKnockbackByEntityPlayer)
 
+        // Used to prevent wind charges from affecting armour stands
+        val animalPush = PermissionExecutor(EntityKnockbackByEntityEvent::class.java,
+            Companion::cancelAnimalPush, Companion::getEntityKnockbackByEntityLocations,
+            Companion::getEntityKnockbackByEntityPlayer)
+
         /**
          * Cancels any cancellable event.
          */
@@ -674,11 +679,21 @@ class PermissionBehaviour {
         }
 
         /**
-         * Cancels the action of breaking a pot with a projectile.
+         * Cancels the action of pushing armour stands with wind charges.
          */
         private fun cancelArmourStandPush(listener: Listener, event: Event): Boolean {
             if (event !is EntityKnockbackByEntityEvent) return false
             if (event.entity !is ArmorStand) return false
+            event.isCancelled = true
+            return true
+        }
+
+        /**
+         * Cancels the action of pushing animals with wind charges.
+         */
+        private fun cancelAnimalPush(listener: Listener, event: Event): Boolean {
+            if (event !is EntityKnockbackByEntityEvent) return false
+            if (event.entity !is Animals && event.entity !is Villager) return false
             event.isCancelled = true
             return true
         }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: BellClaims
-version: 0.3.5
+version: 0.3.6
 api-version: '1.21'
 main: dev.mizarc.bellclaims.BellClaims
 softdepend: [Vault]


### PR DESCRIPTION
Players should not be able to push animals or villagers around with wind charges without the Husbandry permission. This ensures that players cannot simply throw animals out of their pens and then steal or even kill them that way.

Players also should not be able to push armour stands around the same way, this makes sense as a build permission.