### PR TITLE
Fixed player splash potions not working and reworked potion dispense behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Protection against wind charges being used to push animals and villagers, protected by the husbandry permission.
 - Protection against wind charges being used to push armour stands. Requires the build permission.
 
+### Changed
+- Splash potions are now completely negated if dispensed into a claim, with per entity checks only required when dispensed onto outer edge of claim.
+
+### Fixed
+- Dispense flag cancels splash potions entirely, rather than just ones thrown by a dispenser.
+
 ## [0.3.5]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ### Added
 - Protection against wind charges being used to push animals and villagers, protected by the husbandry permission.
 - Protection against wind charges being used to push armour stands. Requires the build permission.
+- Protection against witches affecting animals and villagers with splash potions. Bypassed by the mob griefing flag.
 
 ### Changed
 - Splash potions are now completely negated if dispensed into a claim, with per entity checks only required when dispensed onto outer edge of claim.
@@ -23,7 +24,6 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 - Server crashing due to math error when certain claim partition configurations are attempting to be visualised.
-
 
 ## [0.3.4]
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
@@ -72,7 +72,8 @@ enum class Flag(val rules: Array<RuleExecutor>) {
     Dispensers(arrayOf(
         RuleBehaviour.dispense,
         RuleBehaviour.dispensedSplashPotion,
-        RuleBehaviour.dispensedLingeringPotion
+        RuleBehaviour.dispensedLingeringPotionSplash,
+        RuleBehaviour.dispensedLingeringPotionEffect
     )),
 
     Sponge(arrayOf(

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/flags/Flag.kt
@@ -30,7 +30,8 @@ enum class Flag(val rules: Array<RuleExecutor>) {
         RuleBehaviour.creeperExplode,
         RuleBehaviour.creeperDamageStaticEntity,
         RuleBehaviour.creeperDamageHangingEntity,
-        RuleBehaviour.potBreak
+        RuleBehaviour.potBreak,
+        RuleBehaviour.mobSplashPotion
     )),
 
     /**

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -734,23 +734,27 @@ class RuleBehaviour {
 
             if (dispenserClaim == projectileClaim) return false
             event.isCancelled = true
-            return false
+            return true
         }
-
 
         private fun cancelLingeringPotionEffect(event: Event, claimService: ClaimService,
                                                 partitionService: PartitionService, flagService: FlagService): Boolean {
             if (event !is AreaEffectCloudApplyEvent) return false
             if (event.entity.source is Player || event.entity.source is Monster) return false
+            val potionClaim = partitionService.getByLocation(event.entity.location)?.let {
+                claimService.getById(it.claimId) }
+
+            // Check each entity to see if they should be affected
             val affectedEntities = event.affectedEntities.toMutableList()
             for (entity in event.affectedEntities) {
                 val entityClaim = partitionService.getByLocation(entity.location)?.let {
-                    claimService.getById(it.claimId) }
-                if (entityClaim == null) continue
+                    claimService.getById(it.claimId) } ?: continue
+                if (entityClaim == potionClaim) continue
                 if (entity !is Monster) affectedEntities.remove(entity)
             }
-            event.affectedEntities.removeAll(affectedEntities)
-            return false
+            event.affectedEntities.clear()
+            event.affectedEntities.addAll(affectedEntities)
+            return true
         }
 
         private fun cancelBlockDispenseEvent(event: Event, claimService: ClaimService,

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -36,6 +36,7 @@ import org.bukkit.event.hanging.HangingBreakEvent
 import org.bukkit.event.weather.LightningStrikeEvent
 import org.bukkit.event.world.StructureGrowEvent
 import org.bukkit.inventory.ItemStack
+import org.bukkit.projectiles.BlockProjectileSource
 
 /**
  * A data structure that contains the type of event [eventClass], the function to handle the result of the event
@@ -684,6 +685,8 @@ class RuleBehaviour {
         private fun cancelSplashPotionEffect(event: Event, claimService: ClaimService,
                                              partitionService: PartitionService, flagService: FlagService): Boolean {
             if (event !is PotionSplashEvent) return false
+            val projectile = event.entity as Projectile
+            if (projectile.shooter !is BlockProjectileSource) return false
             for (entity in event.affectedEntities) {
                 if (entity !is Monster) {
                     event.setIntensity(entity, 0.0)
@@ -707,6 +710,8 @@ class RuleBehaviour {
         private fun cancelLingeringPotionEffect(event: Event, claimService: ClaimService,
                                                 partitionService: PartitionService, flagService: FlagService): Boolean {
             if (event !is AreaEffectCloudApplyEvent) return false
+            val projectile = event.entity as Projectile
+            if (projectile.shooter !is BlockProjectileSource) return false
             event.affectedEntities.removeAll { it !is Monster }
             return false
         }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -698,7 +698,18 @@ class RuleBehaviour {
             if (dispenser == null) return false
             val dispenserClaim = partitionService.getByLocation(dispenser.block.location)?.let {
                 claimService.getById(it.claimId) }
+            val potionClaim = partitionService.getByLocation(projectile.location)?.let {
+                claimService.getById(it.claimId) }
 
+            // Cancel if the potion is thrown into the claim
+            println(dispenserClaim)
+            println(potionClaim)
+            if (dispenserClaim != potionClaim) {
+                event.isCancelled = true
+                return true
+            }
+
+            // For the splash affect, cancel out non-monster mobs that are inside the claim
             for (entity in event.affectedEntities) {
                 val entityClaim = partitionService.getByLocation(entity.location)?.let {
                     claimService.getById(it.claimId) }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/FlagBehaviour.kt
@@ -674,6 +674,13 @@ class RuleBehaviour {
                                         partitionService: PartitionService): List<Claim> {
             if (event !is PotionSplashEvent) return listOf()
             val affectedClaims = mutableListOf<Claim>()
+
+            // Include the claim the potion lands in
+            val potionClaim = partitionService.getByLocation(event.entity.location)?.let {
+                claimService.getById(it.claimId) }
+            if (potionClaim != null) affectedClaims.add(potionClaim)
+
+            // Include through all affected entities
             for (entity in event.affectedEntities) {
                 val partition = partitionService.getByLocation(entity.location) ?: continue
                 val claim = claimService.getById(partition.claimId) ?: continue


### PR DESCRIPTION
This was initially just supposed to be a fix of the dispenser flag overextending its protection to players throwing splash potions in claims, but ended up with a bit more than that.

Dispensed potions now disappear if they originated from outside the claim and landed inside the claim. The filtering of hostile mobs and passive mobs still apply if the splash happens outside the claim but affects entities inside the claim. This behaviour is also shared with lingering potions.

Another addition is the protection from witch potions, as witches throwing potions should not be able to affect passive mobs.