### PR TITLE
Update dependencies to support MC 1.21.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [0.3.7]
+This is a version bump only release. Update to support MC version 1.21.3.
+
+### Fixed
+- Inability to use inventory GUIs with MC 1.21.3
+
 ## [0.3.6]
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,16 +29,16 @@ repositories {
 dependencies {
     testImplementation(kotlin("test"))
     testImplementation("io.mockk:mockk:1.13.11")
-    testImplementation("io.papermc.paper:paper-api:1.21-R0.1-SNAPSHOT")
+    testImplementation("io.papermc.paper:paper-api:1.21.3-R0.1-SNAPSHOT")
     testImplementation("com.github.MilkBowl:VaultAPI:1.7")
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
-    compileOnly("io.papermc.paper:paper-api:1.21-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.3-R0.1-SNAPSHOT")
     shadow("org.jetbrains.kotlin:kotlin-stdlib")
     implementation ("org.slf4j:slf4j-nop:2.0.13")
     implementation("com.zaxxer:HikariCP:5.1.0")
     implementation("co.aikar:acf-paper:0.5.1-SNAPSHOT")
     implementation("co.aikar:idb-core:1.0.0-SNAPSHOT")
-    implementation("com.github.stefvanschie.inventoryframework:IF:0.10.17")
+    implementation("com.github.stefvanschie.inventoryframework:IF:0.10.19")
     compileOnly("com.github.MilkBowl:VaultAPI:1.7")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "dev.mizarc"
-version = "0.3.6"
+version = "0.3.7"
 
 repositories {
     mavenCentral()

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: BellClaims
-version: 0.3.6
+version: 0.3.7
 api-version: '1.21'
 main: dev.mizarc.bellclaims.BellClaims
 softdepend: [Vault]


### PR DESCRIPTION
This just solves the inability to use the inventory GUI on servers of version 1.21.3