### PR TITLE
Add harvesting permission and special harvester system for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ### Added
 - Protection against players stealing animals by putting them in vehicles. Bypassed by the animal vehicle flag.
 - Protection against harvesting crops such as berry bushes. Requires the harvest permission.
+- Crops such as wheat, carrots, and cocoa beans can now be right click harvested which auto replants the seeds. This can be disabled in config but allows the harvest permission to work to its fullest.
 
 ### Changed
 - Using bone meal on crops is now covered by the harvest permission. Bone meal usage on non crops still covered by the build permission.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Added
 - Protection against players stealing animals by putting them in vehicles. Bypassed by the animal vehicle flag.
+- Protection against harvesting crops such as berry bushes. Requires the harvest permission.
+
+### Changed
+- Using bone meal on crops is now covered by the harvest permission. Bone meal usage on non crops still covered by the build permission.
 
 ## [0.3.5]
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
     implementation("com.zaxxer:HikariCP:5.1.0")
     implementation("co.aikar:acf-paper:0.5.1-SNAPSHOT")
     implementation("co.aikar:idb-core:1.0.0-SNAPSHOT")
-    implementation("com.github.stefvanschie.inventoryframework:IF:0.10.17")
+    implementation("com.github.stefvanschie.inventoryframework:IF:0.10.19")
     compileOnly("com.github.MilkBowl:VaultAPI:1.7")
 }
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
@@ -238,6 +238,6 @@ class BellClaims : JavaPlugin() {
         server.pluginManager.registerEvents(
             PartitionUpdateListener(claimService, partitionService, playerStateService, visualiser), this)
         server.pluginManager.registerEvents(BlockLaunchListener(this), this)
-        server.pluginManager.registerEvents(HarvestReplantListener(), this)
+        server.pluginManager.registerEvents(HarvestReplantListener(config), this)
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
@@ -238,5 +238,6 @@ class BellClaims : JavaPlugin() {
         server.pluginManager.registerEvents(
             PartitionUpdateListener(claimService, partitionService, playerStateService, visualiser), this)
         server.pluginManager.registerEvents(BlockLaunchListener(this), this)
+        server.pluginManager.registerEvents(HarvestReplantListener(), this)
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
@@ -35,6 +35,7 @@ enum class ClaimPermission(val events: Array<PermissionExecutor>) {
      */
     Harvest(arrayOf(
         PermissionBehaviour.cropHarvest,
+        PermissionBehaviour.cropFertilize
     )),
 
     /**

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/permissions/ClaimPermission.kt
@@ -31,6 +31,13 @@ enum class ClaimPermission(val events: Array<PermissionExecutor>) {
     )),
 
     /**
+     * When plants are harvested and replanted by a player.
+     */
+    Harvest(arrayOf(
+        PermissionBehaviour.cropHarvest,
+    )),
+
+    /**
      * When a container is opened by a player.
      */
     ContainerInspect(arrayOf(PermissionBehaviour.openInventory)),

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/persistence/Config.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/persistence/Config.kt
@@ -13,6 +13,7 @@ class Config(val plugin: Plugin) {
     var distanceBetweenClaims = 0
     var visualiserHideDelayPeriod = 0.0
     var visualiserRefreshPeriod = 0.0
+    var rightClickHarvest = true
     var pluginLanguage = "EN"
 
     init {
@@ -28,6 +29,7 @@ class Config(val plugin: Plugin) {
         distanceBetweenClaims = configFile.getInt("distance_between_claims")
         visualiserHideDelayPeriod = configFile.getDouble("visualiser_hide_delay_period")
         visualiserRefreshPeriod = configFile.getDouble("visualiser_refresh_period")
+        rightClickHarvest = configFile.getBoolean("right_click_harvest")
         pluginLanguage = configFile.getString("plugin_language") ?: "EN"
     }
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/PermissionBehaviour.kt
@@ -100,7 +100,7 @@ class PermissionBehaviour {
             Companion::getHangingBreakByEntityEventLocations, Companion::getHangingBreakByEntityEventPlayer)
 
         // Used for plant fertilisation with bone meal
-        val fertilize = PermissionExecutor(BlockFertilizeEvent::class.java, Companion::cancelEvent,
+        val fertilize = PermissionExecutor(BlockFertilizeEvent::class.java, Companion::cancelNonCropFertilize,
             Companion::getBlockLocations, Companion::getBlockFertilizeEventPlayer)
 
         // Used for inventories that either store something or will have an effect in the world from being used
@@ -255,6 +255,10 @@ class PermissionBehaviour {
         // Used to prevent players from harvesting crops
         val cropHarvest = PermissionExecutor(PlayerHarvestBlockEvent::class.java, Companion::cancelEvent,
             Companion::getPlayerHarvestBlockLocations, Companion::getPlayerHarvestBlockPlayer)
+
+        // Used to prevent using bone meal on crops
+        val cropFertilize = PermissionExecutor(BlockFertilizeEvent::class.java, Companion::cancelBoneMealOnCrops,
+            Companion::getBlockLocations, Companion::getBlockFertilizeEventPlayer)
 
         /**
          * Cancels any cancellable event.
@@ -667,6 +671,44 @@ class PermissionBehaviour {
         private fun cancelProjectilePotBreak(listener: Listener, event: Event): Boolean {
             if (event !is EntityChangeBlockEvent) return false
             if (event.block.blockData !is DecoratedPot) return false
+            event.isCancelled = true
+            return true
+        }
+
+        /**
+         * Cancels the action of using bone meal on a non crop.
+         */
+        private fun cancelNonCropFertilize(listener: Listener, event: Event): Boolean {
+            if (event !is BlockFertilizeEvent) return false
+
+            val cropMaterials = setOf(
+                Material.WHEAT, Material.CARROTS, Material.POTATOES, Material.BEETROOTS,
+                Material.COCOA, Material.SWEET_BERRIES, Material.GLOW_BERRIES,
+                Material.MELON_STEM, Material.PUMPKIN_STEM
+            )
+            if (event.block.type in cropMaterials) {
+                return false
+            }
+
+            event.isCancelled = true
+            return true
+        }
+
+        /**
+         * Cancels the action of using bone meal on a crop.
+         */
+        private fun cancelBoneMealOnCrops(listener: Listener, event: Event): Boolean {
+            if (event !is BlockFertilizeEvent) return false
+
+            val cropMaterials = setOf(
+                Material.WHEAT, Material.CARROTS, Material.POTATOES, Material.BEETROOTS,
+                Material.COCOA, Material.SWEET_BERRIES, Material.GLOW_BERRIES,
+                Material.MELON_STEM, Material.PUMPKIN_STEM
+            )
+            if (event.block.type !in cropMaterials) {
+                return false
+            }
+
             event.isCancelled = true
             return true
         }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/PermissionBehaviour.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/behaviours/PermissionBehaviour.kt
@@ -252,6 +252,10 @@ class PermissionBehaviour {
         val potBreak = PermissionExecutor(EntityChangeBlockEvent::class.java, Companion::cancelProjectilePotBreak,
             Companion::getEntityChangeBlockLocations, Companion::getEntityChangeBlockPlayer)
 
+        // Used to prevent players from harvesting crops
+        val cropHarvest = PermissionExecutor(PlayerHarvestBlockEvent::class.java, Companion::cancelEvent,
+            Companion::getPlayerHarvestBlockLocations, Companion::getPlayerHarvestBlockPlayer)
+
         /**
          * Cancels any cancellable event.
          */
@@ -888,9 +892,20 @@ class PermissionBehaviour {
             return listOf(location)
         }
 
+        /**
+         * Gets the affected locations of EntityChangeBlockEvent.
+         */
         private fun getEntityChangeBlockLocations(event: Event): List<Location> {
             if (event !is EntityChangeBlockEvent) return listOf()
             return listOf(event.block.location)
+        }
+
+        /**
+         * Gets the affected locations of PlayerHarvestBlockEvent.
+         */
+        private fun getPlayerHarvestBlockLocations(event: Event): List<Location> {
+            if (event !is PlayerHarvestBlockEvent) return listOf()
+            return listOf(event.harvestedBlock.location)
         }
 
         /**
@@ -1154,6 +1169,14 @@ class PermissionBehaviour {
                 if (projectile.shooter is Player) return projectile.shooter as Player
             }
             return null
+        }
+
+        /**
+         * Gets the player that is triggering the PlayerHarvestBlock.
+         */
+        private fun getPlayerHarvestBlockPlayer(event: Event): Player? {
+            if (event !is PlayerHarvestBlockEvent) return null
+            return event.player
         }
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/HarvestReplantListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/HarvestReplantListener.kt
@@ -1,0 +1,39 @@
+package dev.mizarc.bellclaims.interaction.listeners
+
+import org.bukkit.Material
+import org.bukkit.Sound
+import org.bukkit.block.data.Ageable
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerInteractEvent
+
+class HarvestReplantListener: Listener {
+    @EventHandler
+    fun onInventoryClose(event: PlayerInteractEvent) {
+        // Check if clicked block in set
+        val clickedBlock = event.clickedBlock ?: return
+        val cropMaterials = setOf(
+            Material.WHEAT, Material.CARROTS, Material.POTATOES,
+            Material.BEETROOTS, Material.COCOA, Material.NETHER_WART
+        )
+        if (clickedBlock.type !in cropMaterials) return
+
+        // Check if the block is an 'Ageable' crop (covers most common crops)
+        val blockData = clickedBlock.blockData
+        if (blockData is Ageable) {
+            val ageableData = blockData
+            if (ageableData.age == ageableData.maximumAge) {
+                event.isCancelled = true
+                event.player.swingMainHand()
+                val harvested = clickedBlock.breakNaturally()
+
+                // Replant if harvest is successful
+                if (harvested) {
+                    ageableData.age = 0
+                    clickedBlock.blockData = ageableData
+                }
+                event.player.playSound(clickedBlock.location, Sound.ITEM_CROP_PLANT, 1.0f, 1.0f)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/HarvestReplantListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/HarvestReplantListener.kt
@@ -1,5 +1,6 @@
 package dev.mizarc.bellclaims.interaction.listeners
 
+import dev.mizarc.bellclaims.infrastructure.persistence.Config
 import org.bukkit.Material
 import org.bukkit.Sound
 import org.bukkit.block.data.Ageable
@@ -9,13 +10,14 @@ import org.bukkit.event.block.Action
 import org.bukkit.event.player.PlayerHarvestBlockEvent
 import org.bukkit.event.player.PlayerInteractEvent
 
-class HarvestReplantListener: Listener {
+class HarvestReplantListener(private val config: Config): Listener {
     @EventHandler
     fun onInventoryClose(event: PlayerInteractEvent) {
         // Check if clicked block in set
         val clickedBlock = event.clickedBlock ?: return
         if (event.action != Action.RIGHT_CLICK_BLOCK) return
         val hand = event.hand ?: return
+        if (!config.rightClickHarvest) return
         val cropMaterials = setOf(
             Material.WHEAT, Material.CARROTS, Material.POTATOES,
             Material.BEETROOTS, Material.COCOA, Material.NETHER_WART

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/HarvestReplantListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/HarvestReplantListener.kt
@@ -5,6 +5,7 @@ import org.bukkit.Sound
 import org.bukkit.block.data.Ageable
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
+import org.bukkit.event.block.Action
 import org.bukkit.event.player.PlayerHarvestBlockEvent
 import org.bukkit.event.player.PlayerInteractEvent
 
@@ -13,6 +14,7 @@ class HarvestReplantListener: Listener {
     fun onInventoryClose(event: PlayerInteractEvent) {
         // Check if clicked block in set
         val clickedBlock = event.clickedBlock ?: return
+        if (event.action != Action.RIGHT_CLICK_BLOCK) return
         val hand = event.hand ?: return
         val cropMaterials = setOf(
             Material.WHEAT, Material.CARROTS, Material.POTATOES,

--- a/src/main/kotlin/dev/mizarc/bellclaims/utils/PermissionDisplay.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/utils/PermissionDisplay.kt
@@ -14,6 +14,7 @@ import org.bukkit.entity.Item
 fun ClaimPermission.getIcon(): ItemStack {
     return when (this) {
         ClaimPermission.Build -> ItemStack(Material.DIAMOND_PICKAXE)
+        ClaimPermission.Harvest -> ItemStack(Material.WHEAT)
         ClaimPermission.ContainerInspect -> ItemStack(Material.CHEST)
         ClaimPermission.DisplayManipulate -> ItemStack(Material.ARMOR_STAND)
         ClaimPermission.VehicleDeploy -> ItemStack(Material.MINECART)
@@ -36,6 +37,7 @@ fun ClaimPermission.getIcon(): ItemStack {
 fun ClaimPermission.getDisplayName(): String {
     return when (this) {
         ClaimPermission.Build -> getLangText("NameClaimPermissionBuild")
+        ClaimPermission.Harvest -> getLangText("NameClaimPermissionHarvest")
         ClaimPermission.ContainerInspect -> getLangText("NameClaimPermissionContainerInspect")
         ClaimPermission.DisplayManipulate -> getLangText("NameClaimPermissionDisplayManipulate")
         ClaimPermission.VehicleDeploy -> getLangText("NameClaimPermissionVehicleDeploy")
@@ -58,6 +60,7 @@ fun ClaimPermission.getDisplayName(): String {
 fun ClaimPermission.getDescription(): String {
     return when (this) {
         ClaimPermission.Build -> getLangText("DescClaimPermissionBuild")
+        ClaimPermission.Harvest -> getLangText("DescClaimPermissionHarvest")
         ClaimPermission.ContainerInspect -> getLangText("DescClaimPermissionContainerInspect")
         ClaimPermission.DisplayManipulate -> getLangText("DescClaimPermissionDisplayManipulate")
         ClaimPermission.VehicleDeploy -> getLangText("DescClaimPermissionVehicleDeploy")

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -6,7 +6,7 @@ distance_between_claims: 1
 visualiser_hide_delay_period: 2 # Value in seconds
 visualiser_refresh_period: 1 # Value in seconds
 plugin_language: EN
-
+right_click_harvest: true
 #NOT COMPLETED
 # EN - Original
 # RU - Machine translation (Temporary)

--- a/src/main/resources/lang_EN.yml
+++ b/src/main/resources/lang_EN.yml
@@ -29,6 +29,7 @@ DescFlagAnimalVehicle: "Allows animals to enter vehicles such as boats and minec
 # --- PermissionDisplay.kt ---
 
 NameClaimPermissionBuild: "Build"
+NameClaimPermissionHarvest: "Harvest"
 NameClaimPermissionContainerInspect: "Inspect Containers"
 NameClaimPermissionDisplayManipulate: "Manipulate"
 NameClaimPermissionVehicleDeploy: "Deploy Vehicles"
@@ -42,6 +43,7 @@ NameClaimPermissionEventStart: "Raid"
 NameClaimPermissionSleep: "Sleep"
 
 DescClaimPermissionBuild: "Grants permission to build"
+DescClaimPermissionHarvest: "Grants permission to harvest and apply bone meal to crops"
 DescClaimPermissionContainerInspect: "Grants permission to open inventories (Chest, Furnace, Anvil)"
 DescClaimPermissionDisplayManipulate: "Grants permission to manipulate display items (Item Frames, Armour Stands, Flower Pots)"
 DescClaimPermissionVehicleDeploy: "Grants permission to break and place vehicles (Boats, Minecarts)"


### PR DESCRIPTION
Initially, the harvest permission was designed to cover sweet berries and glow berries since they weren't protected at all prior to this. As it didn't make sense to exclude other types of crops, a new system was implemented to allow players to harvest other types of crops by simply right clicking, which automatically replants the seeds as well. This was the easiest way around the issue of allowing players to harvest crops without being able to directly modify what crops are being grown in the farm. 

Bone meal on crops is also allowed as part of this permission, but not to other things such as grass.