### PR TITLE
Fixed Anvil GUI check when location is 0, 0, 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ### Changed
 - Using bone meal on crops is now covered by the harvest permission. Bone meal usage on non crops still covered by the build permission.
 
+### Fixed
+- Using custom Anvil GUIs may define location as (0, 0, 0), which blocks players from opening menus if a claim exists at (0, 0)
+
 ## [0.3.7]
 This is a version bump only release. Update to support MC version 1.21.3.
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PlayerClaimProtectionListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PlayerClaimProtectionListener.kt
@@ -178,12 +178,20 @@ class PlayerClaimProtectionListener: Listener, KoinComponent {
     fun onInventoryOpenEvent(event: InventoryOpenEvent) {
         val player = event.player as? Player ?: return
         val location = event.inventory.location ?: return
+
+        // Filter to blocks that hold state (or break like anvils)
         val types = setOf(
             InventoryType.CHEST, InventoryType.SHULKER_BOX, InventoryType.BARREL, InventoryType.FURNACE,
             InventoryType.BLAST_FURNACE, InventoryType.SMOKER, InventoryType.ANVIL, InventoryType.BEACON,
             InventoryType.HOPPER, InventoryType.BREWING, InventoryType.DISPENSER, InventoryType.DROPPER)
         val inventoryType = event.inventory.type
         if (inventoryType !in types) return
+
+        // Special check for anvil from custom GUIs implementing the anvils interface. Location is possibly set to
+        // (0, 0, 0) instead of null, which conflicts with claims created there. Anvil is not a tile entity so this
+        // shouldn't be a problem for performance.
+        if (inventoryType == InventoryType.ANVIL && event.inventory.holder == null) return
+
         val action = PlayerActionType.OPEN_CONTAINER
         cancelIfDisallowed(event, player, location, action)
     }


### PR DESCRIPTION
There was a present issue where if a claim is created at location (0, 0), the claim that exists at that location blocks creation and renaming of claims world wide. This also extends to other plugins that make use of custom anvil GUIs.