### PR TITLE
Change armor stand protection behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 - Using bone meal on crops is now covered by the harvest permission. Bone meal usage on non crops still covered by the build permission.
+- Armor stands can now be hit without a permission, but are still protected from destruction by Build permission.
 
 ### Fixed
 - Using custom Anvil GUIs may define location as (0, 0, 0), which blocks players from opening menus if a claim exists at (0, 0)

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PlayerClaimProtectionListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PlayerClaimProtectionListener.kt
@@ -106,7 +106,7 @@ class PlayerClaimProtectionListener: Listener, KoinComponent {
         if (player == null) return
 
         val action = PlayerActionType.DAMAGE_STATIC_ENTITY
-        cancelIfDisallowed(event, player, event.entity.location, action)
+        cancelIfDisallowedNoMessage(event, player, event.entity.location, action)
     }
 
     @EventHandler
@@ -452,7 +452,7 @@ class PlayerClaimProtectionListener: Listener, KoinComponent {
         if (player == null) return
 
         val action = PlayerActionType.PUSH_ARMOUR_STAND
-        cancelIfDisallowed(event, player, event.entity.location, action)
+        cancelIfDisallowedNoMessage(event, player, event.entity.location, action)
     }
 
     @EventHandler
@@ -579,6 +579,18 @@ class PlayerClaimProtectionListener: Listener, KoinComponent {
                 val playerName = Bukkit.getOfflinePlayer(result.claim.playerId).name ?: "(Name not found)"
                 player.sendActionBar(
                     Component.text("You can't do that in ${playerName}'s claim!") .color(TextColor.color(255, 85, 85)))
+            }
+            else -> return
+        }
+    }
+
+    private fun cancelIfDisallowedNoMessage(event: Cancellable, player: Player, location: Location,
+                                            action: PlayerActionType) {
+        val worldId = location.world.uid
+        val position = location.toPosition2D()
+        when (isPlayerActionAllowed.execute(player.uniqueId, worldId, position, action)) {
+            is Denied -> {
+                event.isCancelled = true
             }
             else -> return
         }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PlayerClaimProtectionListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PlayerClaimProtectionListener.kt
@@ -18,63 +18,23 @@ import org.bukkit.World.Environment
 import org.bukkit.block.data.AnaloguePowerable
 import org.bukkit.block.data.Openable
 import org.bukkit.block.data.Powerable
-import org.bukkit.block.data.type.Bed
-import org.bukkit.block.data.type.DecoratedPot
-import org.bukkit.block.data.type.Farmland
-import org.bukkit.block.data.type.RespawnAnchor
-import org.bukkit.block.data.type.Sign
-import org.bukkit.block.data.type.Switch
-import org.bukkit.entity.AbstractVillager
-import org.bukkit.entity.Animals
-import org.bukkit.entity.ArmorStand
-import org.bukkit.entity.EnderCrystal
-import org.bukkit.entity.Entity
-import org.bukkit.entity.EntityType
-import org.bukkit.entity.GlowItemFrame
-import org.bukkit.entity.ItemFrame
-import org.bukkit.entity.LeashHitch
-import org.bukkit.entity.LivingEntity
-import org.bukkit.entity.Monster
-import org.bukkit.entity.Player
-import org.bukkit.entity.Projectile
-import org.bukkit.entity.Vehicle
-import org.bukkit.entity.Villager
+import org.bukkit.block.data.type.*
+import org.bukkit.entity.*
 import org.bukkit.entity.minecart.ExplosiveMinecart
 import org.bukkit.event.Cancellable
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
-import org.bukkit.event.block.Action
-import org.bukkit.event.block.BlockBreakEvent
-import org.bukkit.event.block.BlockFertilizeEvent
-import org.bukkit.event.block.BlockMultiPlaceEvent
-import org.bukkit.event.block.BlockPlaceEvent
-import org.bukkit.event.block.TNTPrimeEvent
-import org.bukkit.event.entity.AreaEffectCloudApplyEvent
-import org.bukkit.event.entity.EntityChangeBlockEvent
-import org.bukkit.event.entity.EntityDamageByEntityEvent
-import org.bukkit.event.entity.EntityDeathEvent
-import org.bukkit.event.entity.EntityInteractEvent
-import org.bukkit.event.entity.EntityPlaceEvent
-import org.bukkit.event.entity.PotionSplashEvent
-import org.bukkit.event.entity.ProjectileHitEvent
+import org.bukkit.event.block.*
+import org.bukkit.event.entity.*
 import org.bukkit.event.hanging.HangingBreakByEntityEvent
 import org.bukkit.event.inventory.InventoryOpenEvent
 import org.bukkit.event.inventory.InventoryType
-import org.bukkit.event.player.PlayerArmorStandManipulateEvent
-import org.bukkit.event.player.PlayerBedEnterEvent
-import org.bukkit.event.player.PlayerBucketEmptyEvent
-import org.bukkit.event.player.PlayerBucketFillEvent
-import org.bukkit.event.player.PlayerFishEvent
-import org.bukkit.event.player.PlayerHarvestBlockEvent
-import org.bukkit.event.player.PlayerInteractEntityEvent
-import org.bukkit.event.player.PlayerInteractEvent
-import org.bukkit.event.player.PlayerTakeLecternBookEvent
+import org.bukkit.event.player.*
 import org.bukkit.event.raid.RaidTriggerEvent
 import org.bukkit.event.vehicle.VehicleDestroyEvent
 import org.bukkit.event.weather.LightningStrikeEvent
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
-import kotlin.getValue
 
 class PlayerClaimProtectionListener: Listener, KoinComponent {
     private val isPlayerActionAllowed: IsPlayerActionAllowed by inject()
@@ -119,7 +79,6 @@ class PlayerClaimProtectionListener: Listener, KoinComponent {
         }
         if (player == null) return
 
-
         val action = PlayerActionType.DAMAGE_STATIC_ENTITY
         cancelIfDisallowed(event, player, event.entity.location, action)
     }
@@ -129,6 +88,23 @@ class PlayerClaimProtectionListener: Listener, KoinComponent {
     fun onEntityDeathEvent(event: EntityDeathEvent) {
         if (event.entity !is ArmorStand) return
         val player = event.damageSource.causingEntity as? Player ?: return
+        val action = PlayerActionType.DAMAGE_STATIC_ENTITY
+        cancelIfDisallowed(event, player, event.entity.location, action)
+    }
+
+    @EventHandler
+    fun onEntityCombustByEntity(event: EntityCombustByEntityEvent) {
+        if (event.entity !is ArmorStand) return
+
+        // Get the entity as a player, or if entity is projectile get the projectile's shooter if it's a player
+        val hitBy = event.combuster
+        val player: Player? = when (hitBy) {
+            is Player -> hitBy
+            is Projectile -> hitBy.shooter as? Player
+            else -> null
+        }
+        if (player == null) return
+
         val action = PlayerActionType.DAMAGE_STATIC_ENTITY
         cancelIfDisallowed(event, player, event.entity.location, action)
     }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PlayerClaimProtectionListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PlayerClaimProtectionListener.kt
@@ -52,6 +52,7 @@ import org.bukkit.event.block.TNTPrimeEvent
 import org.bukkit.event.entity.AreaEffectCloudApplyEvent
 import org.bukkit.event.entity.EntityChangeBlockEvent
 import org.bukkit.event.entity.EntityDamageByEntityEvent
+import org.bukkit.event.entity.EntityDeathEvent
 import org.bukkit.event.entity.EntityInteractEvent
 import org.bukkit.event.entity.EntityPlaceEvent
 import org.bukkit.event.entity.PotionSplashEvent
@@ -107,7 +108,7 @@ class PlayerClaimProtectionListener: Listener, KoinComponent {
 
     @EventHandler
     fun onEntityDamageByEntityEvent(event: EntityDamageByEntityEvent) {
-        if (event.entity !is ArmorStand && event.entity !is ItemFrame && event.entity !is GlowItemFrame) return
+        if (event.entity !is ItemFrame && event.entity !is GlowItemFrame) return
 
         // Get the entity as a player, or if entity is projectile get the projectile's shooter if it's a player
         val hitBy = event.damager
@@ -119,6 +120,15 @@ class PlayerClaimProtectionListener: Listener, KoinComponent {
         if (player == null) return
 
 
+        val action = PlayerActionType.DAMAGE_STATIC_ENTITY
+        cancelIfDisallowed(event, player, event.entity.location, action)
+    }
+
+    @Suppress("UnstableApiUsage")
+    @EventHandler
+    fun onEntityDeathEvent(event: EntityDeathEvent) {
+        if (event.entity !is ArmorStand) return
+        val player = event.damageSource.causingEntity as? Player ?: return
         val action = PlayerActionType.DAMAGE_STATIC_ENTITY
         cancelIfDisallowed(event, player, event.entity.location, action)
     }


### PR DESCRIPTION
Players are now always able to hit armor stands, but cannot apply knockback or fire effects to it. Destroying armor stands still requires the Build permission.