### PR TITLE
Allow admin override to perform all claim actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,26 +9,30 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ### Added
 - Protection against players stealing animals by putting them in vehicles. Bypassed by the animal vehicle flag.
 - Protection against harvesting crops such as berry bushes. Requires the harvest permission.
-- New "View" permission added for viewing contents without being able to modify.
-- Crops such as wheat, carrots, and cocoa beans can now be right click harvested which auto replants the seeds. This can be disabled in config but allows the harvest permission to work to its fullest.
-- Localizations can now automatically detect player's own locale, falling back to the server locale if not available.
-- All known missing localizations added to the english localization file.
+- New "View" permission is added for viewing contents without being able to modify.
+- Crops such as wheat, carrots, and cocoa beans can now be harvested with a right-click which auto replants the seeds. This can be disabled in config but allows the harvest permission to work to its fullest.
+- Localizations can now automatically detect the player's own locale, falling back to the server locale if not available.
+- All known missing localizations are added to the English localization file.
 - Custom models can be used via resource pack to change the model of the claim and move tools.
 - Custom model ids are editable via config.
+- Override allows you to modify partitions as well as access and manage the claim menu.
+- Leaf litter is now included in the transparency block filter.
 
 ### Changed
-- Using bone meal on crops is now covered by the harvest permission. Bone meal usage on non crops still covered by the build permission.
+- Using bone meal on crops is now covered by the harvest permission. The build permission still covers bone meal usage on non-crops.
 - Armor stands can now be hit without a permission, but are still protected from destruction by Build permission.
-- All languages are now included in the default lang folder on server start, with an override folder for specific admin specifiable overrides.
+- All languages are now included in the default lang folder on server start, with an override folder for specific admin-specifiable overrides.
 - Localization file format now makes use of properties files instead of yml, using a standard key format which should better enforce localization usage over fixed strings.
 - Viewing lecterns moved from redstone trigger to View permission.
 
 ### Removed
-- Machine generated translations removed, only suitable for testing but doubtful of their accuracy.
+- Machine-generated translations removed, only suitable for testing but doubtful of their accuracy.
 
 ### Fixed
 - Using custom Anvil GUIs may define location as (0, 0, 0), which blocks players from opening menus if a claim exists at (0, 0)
 - Bell being duplicated when using the move tool.
+- Claims owned by other players were being rendered as if it's your own claim.
+- Able to select the corner of claims owned by other players even if you can't modify them.
 
 ## [0.3.7]
 This is a version bump only release. Update to support MC version 1.21.3.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,10 +40,10 @@ repositories {
 dependencies {
     testImplementation(kotlin("test"))
     testImplementation("io.mockk:mockk:1.13.11")
-    testImplementation("io.papermc.paper:paper-api:1.21.3-R0.1-SNAPSHOT")
+    testImplementation("io.papermc.paper:paper-api:1.21.5-R0.1-SNAPSHOT")
     testImplementation("com.github.MilkBowl:VaultAPI:1.7")
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
-    compileOnly("io.papermc.paper:paper-api:1.21.3-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.5-R0.1-SNAPSHOT")
     shadow("org.jetbrains.kotlin:kotlin-stdlib")
     implementation ("org.slf4j:slf4j-nop:2.0.13")
     implementation("com.zaxxer:HikariCP:5.1.0")
@@ -51,7 +51,9 @@ dependencies {
     implementation("co.aikar:idb-core:1.0.0-SNAPSHOT")
     implementation("dev.mizarc.inventoryframework:if:0.10.19-fork-1")
     implementation("io.insert-koin:koin-core:4.0.2")
-    compileOnly("com.github.MilkBowl:VaultAPI:1.7")
+    compileOnly("com.github.MilkBowl:VaultAPI:1.7") {
+        exclude(group = "org.bukkit", module = "bukkit")
+    }
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.10.2")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,8 @@ dependencies {
     implementation("dev.mizarc.inventoryframework:if:0.10.19-fork-1")
     implementation("io.insert-koin:koin-core:4.0.2")
     compileOnly("com.github.MilkBowl:VaultAPI:1.7")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.10.2")
 }
 
 java {

--- a/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
@@ -2,17 +2,17 @@ package dev.mizarc.bellclaims
 
 import co.aikar.commands.PaperCommandManager
 import dev.mizarc.bellclaims.di.appModule
-import dev.mizarc.bellclaims.infrastructure.persistence.Config
 import dev.mizarc.bellclaims.interaction.commands.*
 import dev.mizarc.bellclaims.interaction.listeners.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import net.milkbowl.vault.chat.Chat
 import org.bukkit.Bukkit
-import org.bukkit.configuration.file.FileConfiguration
-import org.bukkit.configuration.file.YamlConfiguration
 import org.bukkit.plugin.java.JavaPlugin
 import org.bukkit.scheduler.BukkitScheduler
 import org.koin.core.context.GlobalContext.startKoin
-import java.io.File
 
 
 /**
@@ -21,10 +21,11 @@ import java.io.File
 class BellClaims : JavaPlugin() {
     private lateinit var commandManager: PaperCommandManager
     lateinit var metadata: Chat
-    internal var conf: Config = Config(this)
     private lateinit var scheduler: BukkitScheduler
+    lateinit var pluginScope: CoroutineScope
 
     override fun onEnable() {
+        pluginScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
         scheduler = server.scheduler
         startKoin { modules(appModule(this@BellClaims)) }
         initLang()
@@ -50,6 +51,7 @@ class BellClaims : JavaPlugin() {
     }
 
     override fun onDisable() {
+        pluginScope.cancel()
         logger.info("Bell Claims has been Disabled")
     }
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/anchor/MoveClaimAnchor.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/anchor/MoveClaimAnchor.kt
@@ -1,9 +1,11 @@
 package dev.mizarc.bellclaims.application.actions.claim.anchor
 
 import dev.mizarc.bellclaims.application.actions.claim.GetClaimAtPosition
+import dev.mizarc.bellclaims.application.actions.player.DoesPlayerHaveClaimOverride
 import dev.mizarc.bellclaims.application.persistence.ClaimRepository
 import dev.mizarc.bellclaims.application.results.claim.GetClaimAtPositionResult
 import dev.mizarc.bellclaims.application.results.claim.anchor.MoveClaimAnchorResult
+import dev.mizarc.bellclaims.application.results.player.DoesPlayerHaveClaimOverrideResult
 import dev.mizarc.bellclaims.application.services.WorldManipulationService
 import dev.mizarc.bellclaims.domain.entities.Claim
 import dev.mizarc.bellclaims.domain.values.Position3D
@@ -11,7 +13,8 @@ import java.util.UUID
 
 class MoveClaimAnchor(private val claimRepository: ClaimRepository,
                       private val worldManipulationService: WorldManipulationService,
-                      private val getClaimAtPosition: GetClaimAtPosition
+                      private val getClaimAtPosition: GetClaimAtPosition,
+                      private val doesPlayerHaveClaimOverride: DoesPlayerHaveClaimOverride
 ) {
     fun execute(claimId: UUID, playerId: UUID, newWorldId: UUID, newPosition: Position3D): MoveClaimAnchorResult {
         // Get the claim that is being moved
@@ -29,8 +32,15 @@ class MoveClaimAnchor(private val claimRepository: ClaimRepository,
             return MoveClaimAnchorResult.InvalidPosition
         }
 
+        // Get player's claim override
+        val result = doesPlayerHaveClaimOverride.execute(playerId)
+        val claimOverride = when (result) {
+            is DoesPlayerHaveClaimOverrideResult.StorageError -> false
+            is DoesPlayerHaveClaimOverrideResult.Success -> result.hasOverride
+        }
+
         // Check if the player moving the claim bell is the owner of the claim
-        if (existingClaim.playerId != playerId) {
+        if (existingClaim.playerId != playerId && !claimOverride) {
             return MoveClaimAnchorResult.NoPermission
         }
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/partition/CanRemovePartition.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/partition/CanRemovePartition.kt
@@ -16,11 +16,10 @@ class CanRemovePartition(private val claimRepository: ClaimRepository,
         // Check if removal would result in partitions being disconnected to the claim anchor
         if (isRemoveResultInAnyDisconnected(partition)) return CanRemovePartitionResult.Disconnected
 
-        // Check if claim bell would be outside partition
+        // Check if the claim bell would be outside partition
         val claim = claimRepository.getById(partition.claimId) ?: return CanRemovePartitionResult.StorageError
         if (partitionId == getPrimaryPartition(claim).id) return CanRemovePartitionResult.ExposedClaimAnchor
 
-        partitionRepository.remove(partition.id)
         return CanRemovePartitionResult.Success
     }
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/partition/CreatePartition.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/partition/CreatePartition.kt
@@ -14,7 +14,7 @@ class CreatePartition(private val claimRepository: ClaimRepository,
                       private val partitionRepository: PartitionRepository,
                       private val playerMetadataService: PlayerMetadataService,
                       private val config: MainConfig) {
-    fun execute(claimId: UUID, area: Area): CreatePartitionResult {
+    suspend fun execute(claimId: UUID, area: Area): CreatePartitionResult {
         val partition = Partition(claimId, area)
 
         // Check if selection overlaps an existing claim
@@ -30,7 +30,7 @@ class CreatePartition(private val claimRepository: ClaimRepository,
 
         // Check if the player has reached their claim block limit
         val claim = claimRepository.getById(claimId) ?: return CreatePartitionResult.StorageError
-        val playerBlockLimit = playerMetadataService.getPlayerClaimBlockLimit(claim.playerId)
+        val playerBlockLimit = playerMetadataService.getPlayerClaimBlockLimitAsync(claim.playerId)
         val playerBlockCount = claimRepository.getByPlayer(claim.playerId).flatMap { playerClaim ->
             partitionRepository.getByClaim(playerClaim.id)
         }.sumOf { partition ->

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/partition/ResizePartition.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/partition/ResizePartition.kt
@@ -15,7 +15,7 @@ class ResizePartition(private val claimRepository: ClaimRepository,
                       private val partitionRepository: PartitionRepository,
                       private val playerMetadataService: PlayerMetadataService,
                       private val config: MainConfig) {
-    fun execute(partitionId: UUID, selectedCorner: Position2D, newCorner: Position2D): ResizePartitionResult {
+    suspend fun execute(partitionId: UUID, selectedCorner: Position2D, newCorner: Position2D): ResizePartitionResult {
         val partition = partitionRepository.getById(partitionId) ?: return ResizePartitionResult.StorageError
         val newArea = setNewCorner(selectedCorner, newCorner, partition.area)
         val newPartition = partition.copy(area = newArea)
@@ -40,7 +40,7 @@ class ResizePartition(private val claimRepository: ClaimRepository,
             return ResizePartitionResult.TooSmall(config.minimumPartitionSize)
 
         // Check if the player has reached their claim block limit
-        val playerBlockLimit = playerMetadataService.getPlayerClaimBlockLimit(claim.playerId)
+        val playerBlockLimit = playerMetadataService.getPlayerClaimBlockLimitAsync(claim.playerId)
         val playerBlockCount = claimRepository.getByPlayer(claim.playerId).flatMap { playerClaim ->
             partitionRepository.getByClaim(playerClaim.id)
         }.sumOf { partition ->

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/DisplayVisualisation.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/DisplayVisualisation.kt
@@ -77,15 +77,15 @@ class DisplayVisualisation(private val playerStateRepository: PlayerStateReposit
             // Handle claim not owned by this player
             if (claim.playerId != playerId) {
                 visualised[claim.id] = handleNonOwnedClaimDisplay(playerId, claim).toMutableSet()
+            } else {
+                // Get all partitions linked to found claim
+                val partitions = partitionRepository.getByClaim(claim.id)
+                val areas = partitions.map { it.area }.toMutableSet()
+
+                // Visualise the entire claim border and map it
+                visualised[claim.id] = visualisationService.displayComplete(playerId, areas,
+                    "LIGHT_BLUE_GLAZED_TERRACOTTA", "LIGHT_GRAY_CARPET")
             }
-
-            // Get all partitions linked to found claim
-            val partitions = partitionRepository.getByClaim(claim.id)
-            val areas = partitions.map { it.area }.toMutableSet()
-
-            // Visualise the entire claim border and map it
-            visualised[claim.id] = visualisationService.displayComplete(playerId, areas,
-                "LIGHT_BLUE_GLAZED_TERRACOTTA", "LIGHT_GRAY_CARPET")
         }
         return visualised
     }

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/services/PlayerMetadataService.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/services/PlayerMetadataService.kt
@@ -5,4 +5,6 @@ import java.util.UUID
 interface PlayerMetadataService {
     fun getPlayerClaimLimit(playerId: UUID): Int
     fun getPlayerClaimBlockLimit(playerId: UUID): Int
+    suspend fun getPlayerClaimLimitAsync(playerId: UUID): Int
+    suspend fun getPlayerClaimBlockLimitAsync(playerId: UUID): Int
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/services/scheduling/SchedulerService.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/services/scheduling/SchedulerService.kt
@@ -4,5 +4,6 @@ package dev.mizarc.bellclaims.application.services.scheduling
  * Schedules an event to run after an X amount of time
  */
 interface SchedulerService {
+    fun executeOnMain(task: () -> Unit)
     fun schedule(delayTicks: Long, task: () -> Unit): Task
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/di/Modules.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/di/Modules.kt
@@ -93,12 +93,21 @@ import dev.mizarc.bellclaims.infrastructure.services.VisualisationServiceBukkit
 import dev.mizarc.bellclaims.infrastructure.services.WorldManipulationServiceBukkit
 import dev.mizarc.bellclaims.infrastructure.services.scheduling.SchedulerServiceBukkit
 import dev.mizarc.bellclaims.infrastructure.utilities.LocalizationProviderProperties
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import net.milkbowl.vault.chat.Chat
 import org.bukkit.configuration.file.FileConfiguration
 import org.bukkit.plugin.Plugin
+import org.bukkit.plugin.java.JavaPlugin
+import org.bukkit.scheduler.BukkitScheduler
 import org.koin.core.module.dsl.singleOf
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import java.io.File
+import kotlin.coroutines.CoroutineContext
 
 // Define your Koin module(s) - using a top-level val named appModule is common
 fun appModule(plugin: BellClaims) = module {
@@ -106,8 +115,9 @@ fun appModule(plugin: BellClaims) = module {
     single<Plugin> {plugin}
     single<File> { plugin.dataFolder }
     single<FileConfiguration> { plugin.config }
-    single<Chat> {plugin.metadata }
-
+    single<Chat> { plugin.metadata }
+    single<CoroutineScope> { plugin.pluginScope }
+    single<CoroutineDispatcher>(named("IODispatcher")) { Dispatchers.IO }
 
     // --- Config ---
     single { get<ConfigService>().loadConfig() }

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/PlayerMetadataServiceVault.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/PlayerMetadataServiceVault.kt
@@ -2,6 +2,8 @@ package dev.mizarc.bellclaims.infrastructure.services
 
 import dev.mizarc.bellclaims.application.services.PlayerMetadataService
 import dev.mizarc.bellclaims.config.MainConfig
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import net.milkbowl.vault.chat.Chat
 import org.bukkit.Bukkit
 import java.util.UUID
@@ -9,14 +11,26 @@ import java.util.UUID
 class PlayerMetadataServiceVault(private val metadata: Chat,
                                  private val config: MainConfig): PlayerMetadataService {
     override fun getPlayerClaimLimit(playerId: UUID): Int {
-        return metadata.getPlayerInfoInteger(
-            Bukkit.getServer().worlds[0].name, Bukkit.getOfflinePlayer(playerId),
-            "bellclaims.claim_limit", config.claimLimit)
+        val offlinePlayer = Bukkit.getOfflinePlayer(playerId)
+        return metadata.getPlayerInfoInteger(null, offlinePlayer, "bellclaims.claim_limit", config.claimLimit)
     }
 
     override fun getPlayerClaimBlockLimit(playerId: UUID): Int {
-        return metadata.getPlayerInfoInteger(
-            Bukkit.getServer().worlds[0].name, Bukkit.getOfflinePlayer(playerId),
-            "bellclaims.claim_block_limit", config.claimBlockLimit)
+        val offlinePlayer = Bukkit.getOfflinePlayer(playerId)
+        return metadata.getPlayerInfoInteger(null, offlinePlayer, "bellclaims.claim_block_limit", config.claimBlockLimit)
+    }
+
+    override suspend fun getPlayerClaimLimitAsync(playerId: UUID): Int {
+        val offlinePlayer = Bukkit.getOfflinePlayer(playerId)
+        return withContext(Dispatchers.IO) {
+            metadata.getPlayerInfoInteger(null, offlinePlayer, "bellclaims.claim_limit", config.claimLimit)
+        }
+    }
+
+    override suspend fun getPlayerClaimBlockLimitAsync(playerId: UUID): Int {
+        val offlinePlayer = Bukkit.getOfflinePlayer(playerId)
+        return withContext(Dispatchers.IO) {
+            metadata.getPlayerInfoInteger(null, offlinePlayer, "bellclaims.claim_block_limit", config.claimBlockLimit)
+        }
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/scheduling/SchedulerServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/scheduling/SchedulerServiceBukkit.kt
@@ -6,6 +6,10 @@ import org.bukkit.plugin.Plugin
 import org.bukkit.scheduler.BukkitRunnable
 
 class SchedulerServiceBukkit(private val plugin: Plugin): SchedulerService {
+    override fun executeOnMain(task: () -> Unit) {
+        plugin.server.scheduler.runTask(plugin, Runnable(task))
+    }
+
     override fun schedule(delayTicks: Long, task: () -> Unit): Task {
         val runnable = object : BukkitRunnable() {
             override fun run() {

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimAnchorListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimAnchorListener.kt
@@ -52,7 +52,7 @@ class ClaimAnchorListener(): Listener, KoinComponent {
         }
 
         if (claim != null) {
-            // Check if player has an active claim transfer request
+            // Check if the player has an active claim transfer request
             var playerHasTransferRequest = false
             val transferResult = doesPlayerHaveTransferRequest.execute(claim.id, event.player.uniqueId)
             when (transferResult) {
@@ -62,9 +62,9 @@ class ClaimAnchorListener(): Listener, KoinComponent {
                 }
             }
 
-            // Notify no ability to interact with claim without being owner or without an active transfer request
+            // Notify no ability to interact with the claim without being owner or without an active transfer request
             if (claim.playerId != event.player.uniqueId && !playerHasTransferRequest) {
-                val playerName = Bukkit.getOfflinePlayer(claim.playerId)
+                val playerName = Bukkit.getOfflinePlayer(claim.playerId).name ?: LocalizationKeys.GENERAL_NAME_ERROR
                 event.player.sendActionBar(Component.text(
                     localizationProvider.get(playerId, LocalizationKeys.FEEDBACK_CLAIM_OWNER, playerName))
                     .color(TextColor.color(255, 85, 85)))

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimDestructionListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimDestructionListener.kt
@@ -62,7 +62,7 @@ class ClaimDestructionListener: Listener, KoinComponent {
         // No permission to break bell
         val playerId = event.player.uniqueId
         if (playerId != claim.playerId && !hasOverride) {
-            val playerName = Bukkit.getPlayer(claim.playerId)?.name ?:
+            val playerName = Bukkit.getOfflinePlayer(claim.playerId).name ?:
                 localizationProvider.get(playerId, LocalizationKeys.GENERAL_NAME_ERROR)
             event.player.sendActionBar(
                 Component.text(localizationProvider.get(

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimDestructionListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimDestructionListener.kt
@@ -56,12 +56,12 @@ class ClaimDestructionListener: Listener, KoinComponent {
 
         val hasOverride = when (val result = doesPlayerHaveClaimOverride.execute(event.player.uniqueId)) {
             is DoesPlayerHaveClaimOverrideResult.Success -> result.hasOverride
-            else -> {}
+            else -> false
         }
 
         // No permission to break bell
         val playerId = event.player.uniqueId
-        if (playerId != claim.playerId && hasOverride != true) {
+        if (playerId != claim.playerId && !hasOverride) {
             val playerName = Bukkit.getPlayer(claim.playerId)?.name ?:
                 localizationProvider.get(playerId, LocalizationKeys.GENERAL_NAME_ERROR)
             event.player.sendActionBar(

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolListener.kt
@@ -198,44 +198,103 @@ class EditToolListener: Listener, KoinComponent {
     fun createPartitionBranch(player: Player, location: Location, partitionBuilder: Pair<UUID, Position2D>) {
         val secondPosition = Position2D(location.x.toInt(), location.z.toInt())
         val area = Area(partitionBuilder.second, secondPosition)
-        when (val result = createPartition.execute(partitionBuilder.first, area)) {
-            is CreatePartitionResult.Success -> {
-                player.sendActionBar(Component.text(localizationProvider.get(
-                    player.uniqueId, LocalizationKeys.FEEDBACK_EDIT_TOOL_NEW_PARTITION, result.claim.name, 0))
-                    .color(TextColor.color(85, 255, 85)))
-                firstSelectedCornerCreate.remove(player.uniqueId)
-                val event = PartitionModificationEvent(result.partition)
-                event.callEvent()
-            }
-            is CreatePartitionResult.Disconnected -> {
-                player.sendActionBar(Component.text(localizationProvider.get(
-                    player.uniqueId, LocalizationKeys.FEEDBACK_EDIT_TOOL_NOT_CONNECTED))
-                    .color(TextColor.color(255, 85, 85)))
-            }
-            is CreatePartitionResult.InsufficientBlocks -> {
-                player.sendActionBar(Component.text(localizationProvider.get(
-                    player.uniqueId, LocalizationKeys.FEEDBACK_EDIT_TOOL_INSUFFICIENT, result.requiredExtraBlocks))
-                    .color(TextColor.color(255, 85, 85)))
-            }
-            is CreatePartitionResult.Overlaps -> {
-                player.sendActionBar(Component.text(localizationProvider.get(
-                    player.uniqueId, LocalizationKeys.FEEDBACK_EDIT_TOOL_OVERLAP))
-                    .color(TextColor.color(255, 85, 85)))
-            }
-            is CreatePartitionResult.TooClose -> {
-                player.sendActionBar(Component.text(localizationProvider.get(
-                    player.uniqueId, LocalizationKeys.FEEDBACK_EDIT_TOOL_TOO_CLOSE))
-                    .color(TextColor.color(255, 85, 85)))
-            }
-            is CreatePartitionResult.TooSmall -> {
-                player.sendActionBar(Component.text(localizationProvider.get(
-                    player.uniqueId, LocalizationKeys.FEEDBACK_EDIT_TOOL_MINIMUM_SIZE, result.minimumSize))
-                    .color(TextColor.color(255, 85, 85)))
-            }
-            is CreatePartitionResult.StorageError -> {
-                player.sendActionBar(Component.text(localizationProvider.get(
-                    player.uniqueId, LocalizationKeys.GENERAL_ERROR))
-                    .color(TextColor.color(255, 85, 85)))
+
+        coroutineScope.launch {
+            when (val result = createPartition.execute(partitionBuilder.first, area)) {
+                is CreatePartitionResult.Success -> {
+                    schedulerService.executeOnMain {
+                        player.sendActionBar(
+                            Component.text(
+                                localizationProvider.get(
+                                    player.uniqueId,
+                                    LocalizationKeys.FEEDBACK_EDIT_TOOL_NEW_PARTITION,
+                                    result.claim.name,
+                                    0
+                                )
+                            )
+                                .color(TextColor.color(85, 255, 85))
+                        )
+                        firstSelectedCornerCreate.remove(player.uniqueId)
+                        val event = PartitionModificationEvent(result.partition)
+                        event.callEvent()
+                    }
+                }
+                is CreatePartitionResult.Disconnected -> {
+                    schedulerService.executeOnMain {
+                        player.sendActionBar(
+                            Component.text(
+                                localizationProvider.get(
+                                    player.uniqueId, LocalizationKeys.FEEDBACK_EDIT_TOOL_NOT_CONNECTED
+                                )
+                            )
+                                .color(TextColor.color(255, 85, 85))
+                        )
+                    }
+                }
+                is CreatePartitionResult.InsufficientBlocks -> {
+                    schedulerService.executeOnMain {
+                        player.sendActionBar(
+                            Component.text(
+                                localizationProvider.get(
+                                    player.uniqueId,
+                                    LocalizationKeys.FEEDBACK_EDIT_TOOL_INSUFFICIENT,
+                                    result.requiredExtraBlocks
+                                )
+                            )
+                                .color(TextColor.color(255, 85, 85))
+                        )
+                    }
+                }
+                is CreatePartitionResult.Overlaps -> {
+                    schedulerService.executeOnMain {
+                        player.sendActionBar(
+                            Component.text(
+                                localizationProvider.get(
+                                    player.uniqueId, LocalizationKeys.FEEDBACK_EDIT_TOOL_OVERLAP
+                                )
+                            )
+                                .color(TextColor.color(255, 85, 85))
+                        )
+                    }
+                }
+                is CreatePartitionResult.TooClose -> {
+                    schedulerService.executeOnMain {
+                        player.sendActionBar(
+                            Component.text(
+                                localizationProvider.get(
+                                    player.uniqueId, LocalizationKeys.FEEDBACK_EDIT_TOOL_TOO_CLOSE
+                                )
+                            )
+                                .color(TextColor.color(255, 85, 85))
+                        )
+                    }
+                }
+                is CreatePartitionResult.TooSmall -> {
+                    schedulerService.executeOnMain {
+                        player.sendActionBar(
+                            Component.text(
+                                localizationProvider.get(
+                                    player.uniqueId,
+                                    LocalizationKeys.FEEDBACK_EDIT_TOOL_MINIMUM_SIZE,
+                                    result.minimumSize
+                                )
+                            )
+                                .color(TextColor.color(255, 85, 85))
+                        )
+                    }
+                }
+                is CreatePartitionResult.StorageError -> {
+                    schedulerService.executeOnMain {
+                        player.sendActionBar(
+                            Component.text(
+                                localizationProvider.get(
+                                    player.uniqueId, LocalizationKeys.GENERAL_ERROR
+                                )
+                            )
+                                .color(TextColor.color(255, 85, 85))
+                        )
+                    }
+                }
             }
         }
     }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolListener.kt
@@ -144,13 +144,25 @@ class EditToolListener: Listener, KoinComponent {
             return
         }
 
+        // Get claim override value
+        val result = doesPlayerHaveClaimOverride.execute(player.uniqueId)
+        val hasOverride = when (result) {
+            DoesPlayerHaveClaimOverrideResult.StorageError -> false
+            is DoesPlayerHaveClaimOverrideResult.Success -> result.hasOverride
+        }
+
         // Find claims next to the current selection
+        // Players with override can select any claim, otherwise only allow claims that player owns
         var selectedClaim: Claim? = null
         val adjacentClaims = findAdjacentClaims(location)
-        for (claim in adjacentClaims) {
-            if (claim.playerId == player.uniqueId) {
-                selectedClaim = claim
-                break
+        if (hasOverride) {
+            selectedClaim = adjacentClaims.firstOrNull()
+        } else {
+            for (claim in adjacentClaims) {
+                if (claim.playerId == player.uniqueId) {
+                    selectedClaim = claim
+                    break
+                }
             }
         }
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolListener.kt
@@ -41,7 +41,7 @@ import org.koin.core.component.inject
 import java.util.UUID
 
 /**
- * Actions based on utilizing the claim tool.
+ * Actions based on using the claim tool.
  */
 class EditToolListener: Listener, KoinComponent {
     private val localizationProvider: LocalizationProvider by inject()
@@ -68,6 +68,7 @@ class EditToolListener: Listener, KoinComponent {
         val item = event.item ?: return
         val clickedBlock = event.clickedBlock ?: return
         if (!isItemClaimTool.execute(item.toCustomItemData())) return
+        println("niner")
 
         // Open the menu if in offhand
         if (event.hand == EquipmentSlot.OFF_HAND) {
@@ -83,6 +84,7 @@ class EditToolListener: Listener, KoinComponent {
         // Resizes an existing partition
         val partitionResizer = firstSelectedCornerResize[event.player.uniqueId]
         if (partitionResizer != null) {
+            println("okay")
             resizePartitionBranch(event.player, clickedBlock.location, partitionResizer)
             return
         }
@@ -94,7 +96,7 @@ class EditToolListener: Listener, KoinComponent {
             return
         }
 
-        // Select corner of existing claim for resize operation
+        // Select the corner of an existing claim for resize operation
         if (selectExistingCorner(event.player, clickedBlock.location)) {
             return
         }
@@ -164,7 +166,7 @@ class EditToolListener: Listener, KoinComponent {
 
         val remainingClaimBlockCount = getRemainingClaimBlockCount.execute(player.uniqueId)
 
-        // Check if the player already hit claim block limit
+        // Check if the player already hit their claim block limit
         if (remainingClaimBlockCount < 1) {
             return player.sendActionBar(
                 Component.text(localizationProvider.get(
@@ -238,11 +240,14 @@ class EditToolListener: Listener, KoinComponent {
             else -> return false
         }
 
-        // Check for permission to modify claim.
-        val hasOverride = when (doesPlayerHaveClaimOverride.execute(player.uniqueId)) {
+        // Get claim override value
+        val result = doesPlayerHaveClaimOverride.execute(player.uniqueId)
+        val hasOverride = when (result) {
             DoesPlayerHaveClaimOverrideResult.StorageError -> false
-            is DoesPlayerHaveClaimOverrideResult.Success -> true
+            is DoesPlayerHaveClaimOverrideResult.Success -> result.hasOverride
         }
+
+        // Alert player if they don't have permission to modify
         if (hasOverride) {}
         else if (claim.playerId != player.uniqueId) {
             player.sendActionBar(

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolListener.kt
@@ -68,7 +68,6 @@ class EditToolListener: Listener, KoinComponent {
         val item = event.item ?: return
         val clickedBlock = event.clickedBlock ?: return
         if (!isItemClaimTool.execute(item.toCustomItemData())) return
-        println("niner")
 
         // Open the menu if in offhand
         if (event.hand == EquipmentSlot.OFF_HAND) {
@@ -84,7 +83,6 @@ class EditToolListener: Listener, KoinComponent {
         // Resizes an existing partition
         val partitionResizer = firstSelectedCornerResize[event.player.uniqueId]
         if (partitionResizer != null) {
-            println("okay")
             resizePartitionBranch(event.player, clickedBlock.location, partitionResizer)
             return
         }
@@ -141,7 +139,7 @@ class EditToolListener: Listener, KoinComponent {
         if (partition != null) {
             player.sendActionBar(
                 Component.text(localizationProvider.get(
-                    player.uniqueId, LocalizationKeys.FEEDBACK_EDIT_TOOL_IN_CLAIM))
+                    player.uniqueId, LocalizationKeys.FEEDBACK_EDIT_TOOL_INVALID))
                     .color(TextColor.color(255, 85, 85)))
             return
         }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/MoveToolListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/MoveToolListener.kt
@@ -1,6 +1,7 @@
 package dev.mizarc.bellclaims.interaction.listeners
 
 import dev.mizarc.bellclaims.application.actions.claim.anchor.MoveClaimAnchor
+import dev.mizarc.bellclaims.application.actions.player.DoesPlayerHaveClaimOverride
 import dev.mizarc.bellclaims.application.actions.player.tool.GetClaimIdFromMoveTool
 import dev.mizarc.bellclaims.application.results.claim.anchor.MoveClaimAnchorResult
 import dev.mizarc.bellclaims.application.results.player.tool.GetClaimIdFromMoveToolResult
@@ -25,14 +26,16 @@ class MoveToolListener: Listener, KoinComponent {
 
     @EventHandler
     fun onClaimMoveBlockPlace(event: BlockPlaceEvent) {
-        val playerId = event.player.uniqueId
-        val result = getClaimIdFromMoveTool.execute(event.itemInHand.toCustomItemData())
+        // Get the claim id from the move tool
         val claimId: UUID
+        val result = getClaimIdFromMoveTool.execute(event.itemInHand.toCustomItemData())
         when (result) {
             GetClaimIdFromMoveToolResult.NotMoveTool -> return
             is GetClaimIdFromMoveToolResult.Success -> claimId = result.claimId
         }
 
+        // Perform action to move the claim bell
+        val playerId = event.player.uniqueId
         when (moveClaimAnchor.execute(
             claimId, event.player.uniqueId,
             event.blockPlaced.world.uid, event.blockPlaced.location.toPosition3D())) {

--- a/src/main/kotlin/dev/mizarc/bellclaims/utils/NonFullBlockFiltering.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/utils/NonFullBlockFiltering.kt
@@ -432,7 +432,8 @@ val transparentMaterials = arrayOf(
     Material.CAVE_VINES_PLANT,
     Material.BIG_DRIPLEAF_STEM,
     Material.POTTED_AZALEA_BUSH,
-    Material.POTTED_FLOWERING_AZALEA_BUSH
+    Material.POTTED_FLOWERING_AZALEA_BUSH,
+    Material.LEAF_LITTER
 )
 
 /**

--- a/src/main/resources/lang/defaults/en.properties
+++ b/src/main/resources/lang/defaults/en.properties
@@ -37,7 +37,7 @@ feedback.edit_tool.unequip_resize=Claim tool unequipped. Claim resizing has been
 
 # Destruction
 feedback.destruction.attached=That block is attached to the claim bell
-feedback.destruction.permission=This claim belongs to {0}
+feedback.destruction.permission=You cannot break {0}'s claim bell
 feedback.destruction.pending=Break {0} more times in {1} seconds to destroy this claim
 feedback.destruction.success=Claim {0} has been destroyed
 


### PR DESCRIPTION
Administrators can now perform the following actions alongside building in claims when using /claimoverride:
- Breaking claim bell
- Accessing and editing claim settings
- Modifying the claim partitions using the claim tool

Fixes have also been applied in this PR to do with rendering the claims that you do not own and the messages that are displayed to you.