### PR TITLE
Display the currently selected block in the world with a new terracotta block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
 ## [0.4.0]
+New major beta feature drop! Quality of life changes all around and support for 1.21.5.
 
 ### Added
 - Support for Minecraft 1.21.5
@@ -27,7 +28,6 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - All languages are now included in the default lang folder on server start, with an override folder for specific admin-specifiable overrides.
 - Localization file format now makes use of properties files instead of yml, using a standard key format which should better enforce localization usage over fixed strings.
 - Viewing lecterns moved from redstone trigger to View permission.
-- 
 
 ### Removed
 - Machine-generated translations removed, only suitable for testing but doubtful of their accuracy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - All known missing localizations added to the english localization file.
 - Custom models can be used via resource pack to change the model of the claim and move tools.
 - Custom model ids are editable via config.
+- A new block now indicates the actively selected block while editing partitions.
+- The current partition resize or add operation can be canceled by clicking on the actively selected block.
 
 ### Changed
 - Using bone meal on crops is now covered by the harvest permission. Bone meal usage on non crops still covered by the build permission.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ### Fixed
 - Using custom Anvil GUIs may define location as (0, 0, 0), which blocks players from opening menus if a claim exists at (0, 0)
 - Bell being duplicated when using the move tool.
+- The Main partition isn't correctly indicated by the main partition visualizer blocks.
 
 ## [0.3.7]
 This is a version bump only release. Update to support MC version 1.21.3.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,6 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ### Fixed
 - Using custom Anvil GUIs may define location as (0, 0, 0), which blocks players from opening menus if a claim exists at (0, 0)
 - Bell being duplicated when using the move tool.
-- Claims owned by other players were being rendered as if it's your own claim.
-- Able to select the corner of claims owned by other players even if you can't modify them.
 
 ## [0.3.7]
 This is a version bump only release. Update to support MC version 1.21.3.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ## [0.4.0]
 
 ### Added
+- Support for Minecraft 1.21.5
 - Protection against players stealing animals by putting them in vehicles. Bypassed by the animal vehicle flag.
 - Protection against harvesting crops such as berry bushes. Requires the harvest permission.
 - New "View" permission is added for viewing contents without being able to modify.
@@ -26,6 +27,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - All languages are now included in the default lang folder on server start, with an override folder for specific admin-specifiable overrides.
 - Localization file format now makes use of properties files instead of yml, using a standard key format which should better enforce localization usage over fixed strings.
 - Viewing lecterns moved from redstone trigger to View permission.
+- 
 
 ### Removed
 - Machine-generated translations removed, only suitable for testing but doubtful of their accuracy.

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/ClearSelectionVisualisation.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/ClearSelectionVisualisation.kt
@@ -1,0 +1,29 @@
+package dev.mizarc.bellclaims.application.actions.player.visualisation
+
+import dev.mizarc.bellclaims.application.persistence.PlayerStateRepository
+import dev.mizarc.bellclaims.application.services.VisualisationService
+import dev.mizarc.bellclaims.domain.entities.PlayerState
+import dev.mizarc.bellclaims.domain.values.Position3D
+import java.util.UUID
+
+class ClearSelectionVisualisation(
+    private val playerStateRepository: PlayerStateRepository,
+    private val visualisationService: VisualisationService
+) {
+    fun execute(playerId: UUID, position: Position3D) {
+        var playerState = playerStateRepository.get(playerId)
+        if (playerState == null) {
+            playerState = PlayerState(playerId)
+            playerStateRepository.add(playerState)
+        }
+
+        // Visualise the block if currently visualised
+        val selectedBlock = playerState.selectedBlock
+        if (selectedBlock == null) return
+        visualisationService.clear(playerId, setOf(selectedBlock))
+
+        // Set visualization in the player state
+        playerState.selectedBlock = position
+        playerStateRepository.update(playerState)
+    }
+}

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/ClearSelectionVisualisation.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/ClearSelectionVisualisation.kt
@@ -10,7 +10,7 @@ class ClearSelectionVisualisation(
     private val playerStateRepository: PlayerStateRepository,
     private val visualisationService: VisualisationService
 ) {
-    fun execute(playerId: UUID, position: Position3D) {
+    fun execute(playerId: UUID) {
         var playerState = playerStateRepository.get(playerId)
         if (playerState == null) {
             playerState = PlayerState(playerId)
@@ -23,7 +23,7 @@ class ClearSelectionVisualisation(
         visualisationService.clear(playerId, setOf(selectedBlock))
 
         // Set visualization in the player state
-        playerState.selectedBlock = position
+        playerState.selectedBlock = null
         playerStateRepository.update(playerState)
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/ClearVisualisation.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/ClearVisualisation.kt
@@ -4,9 +4,12 @@ import dev.mizarc.bellclaims.application.persistence.PlayerStateRepository
 import dev.mizarc.bellclaims.application.services.VisualisationService
 import dev.mizarc.bellclaims.domain.entities.PlayerState
 import java.util.UUID
+import kotlin.collections.flatten
 
-class ClearVisualisation(private val playerStateRepository: PlayerStateRepository,
-                         private val visualisationService: VisualisationService) {
+class ClearVisualisation(
+    private val playerStateRepository: PlayerStateRepository,
+    private val visualisationService: VisualisationService
+) {
     /**
      * Clears the claim visualisation for the target player
      */
@@ -18,13 +21,16 @@ class ClearVisualisation(private val playerStateRepository: PlayerStateRepositor
         }
 
         // Get all the blocks to unvisualise, including partition-based and currently selected
-        val blocksToUnvisualise = playerState.visualisedClaims.values.flatten().toMutableSet()
+        val claimBlocksToUnvisualise = playerState.visualisedClaims.values.flatten().toMutableSet()
+        claimBlocksToUnvisualise.addAll(playerState.visualisedPartitions.values.flatMap { innerMap -> innerMap.values }
+            .flatten())
 
         // Unvisualise
-        visualisationService.clear(playerId, blocksToUnvisualise)
+        visualisationService.clear(playerId, claimBlocksToUnvisualise)
 
         // Nullify visualizations in the player state
         playerState.visualisedClaims.clear()
+        playerState.visualisedPartitions.clear()
         playerState.isVisualisingClaims = false
         playerStateRepository.update(playerState)
         return

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/ClearVisualisation.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/ClearVisualisation.kt
@@ -8,7 +8,7 @@ import java.util.UUID
 class ClearVisualisation(private val playerStateRepository: PlayerStateRepository,
                          private val visualisationService: VisualisationService) {
     /**
-     * Clears the claim visualisation for target player
+     * Clears the claim visualisation for the target player
      */
     fun execute(playerId: UUID) {
         var playerState = playerStateRepository.get(playerId)
@@ -17,7 +17,13 @@ class ClearVisualisation(private val playerStateRepository: PlayerStateRepositor
             playerStateRepository.add(playerState)
         }
 
-        visualisationService.clear(playerId, playerState.visualisedClaims.values.flatten().toSet())
+        // Get all the blocks to unvisualise, including partition-based and currently selected
+        val blocksToUnvisualise = playerState.visualisedClaims.values.flatten().toMutableSet()
+
+        // Unvisualise
+        visualisationService.clear(playerId, blocksToUnvisualise)
+
+        // Nullify visualizations in the player state
         playerState.visualisedClaims.clear()
         playerState.isVisualisingClaims = false
         playerStateRepository.update(playerState)

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/DisplaySelectionVisualisation.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/DisplaySelectionVisualisation.kt
@@ -1,0 +1,30 @@
+package dev.mizarc.bellclaims.application.actions.player.visualisation
+
+import dev.mizarc.bellclaims.application.persistence.PlayerStateRepository
+import dev.mizarc.bellclaims.application.services.VisualisationService
+import dev.mizarc.bellclaims.domain.entities.PlayerState
+import dev.mizarc.bellclaims.domain.values.Position3D
+import java.util.UUID
+
+class DisplaySelectionVisualisation(
+    private val playerStateRepository: PlayerStateRepository,
+    private val visualisationService: VisualisationService
+) {
+    private val selectionBlock = "LIME_GLAZED_TERRACOTTA"
+    private val selectionCarpet = "LIME_CARPET"
+
+    fun execute(playerId: UUID, position: Position3D) {
+        var playerState = playerStateRepository.get(playerId)
+        if (playerState == null) {
+            playerState = PlayerState(playerId)
+            playerStateRepository.add(playerState)
+        }
+
+        // Visualise the block
+        visualisationService.displaySelected(playerId, position, selectionBlock, selectionCarpet)
+
+        // Set visualization in the player state
+        playerState.selectedBlock = position
+        playerStateRepository.update(playerState)
+    }
+}

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/DisplayVisualisation.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/DisplayVisualisation.kt
@@ -48,11 +48,11 @@ class DisplayVisualisation(private val playerStateRepository: PlayerStateReposit
         }
         else {
             borders.putAll(displayComplete(playerId, playerState, playerPosition))
+            playerState.visualisedClaims = borders
         }
 
         // Set visualisation in player state
         playerState.scheduledVisualiserHide?.cancel()
-        playerState.visualisedClaims = borders
         playerState.isVisualisingClaims = true
         playerState.lastVisualisationTime = Instant.now()
         playerStateRepository.update(playerState)
@@ -111,7 +111,10 @@ class DisplayVisualisation(private val playerStateRepository: PlayerStateReposit
 
             // Handle claim not owned by this player
             if (claim.playerId != playerId) {
-                visualised[claim.id] = handleNonOwnedClaimDisplay(playerId, claim).toMutableSet()
+                val positions = handleNonOwnedClaimDisplay(playerId, claim).toMutableSet()
+                visualised[claim.id] = positions
+                playerState.visualisedClaims[claim.id] = positions
+                continue
             }
 
             // Visualise the partition and add it to the map assigned to the partition's claim
@@ -132,6 +135,7 @@ class DisplayVisualisation(private val playerStateRepository: PlayerStateReposit
             }
 
             visualised.computeIfAbsent(claim.id) { mutableSetOf() }.addAll(newPositions)
+            playerState.visualisedPartitions.computeIfAbsent(claim.id) { mutableMapOf() }[partition.id] = newPositions
         }
         return visualised
     }

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/DisplayVisualisation.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/DisplayVisualisation.kt
@@ -44,10 +44,10 @@ class DisplayVisualisation(private val playerStateRepository: PlayerStateReposit
         // Change visualiser depending on view mode
         val borders: MutableMap<UUID, Set<Position3D>> = mutableMapOf()
         if (playerState.claimToolMode == 1) {
-            borders.putAll(displayPartitioned(playerId, playerPosition))
+            borders.putAll(displayPartitioned(playerId, playerState, playerPosition))
         }
         else {
-            borders.putAll(displayComplete(playerId, playerPosition))
+            borders.putAll(displayComplete(playerId, playerState, playerPosition))
         }
 
         // Set visualisation in player state
@@ -62,7 +62,7 @@ class DisplayVisualisation(private val playerStateRepository: PlayerStateReposit
     /**
      * Visualise all of a player's claims with only outer borders.
      */
-    private fun displayComplete(playerId: UUID, playerPosition: Position3D): Map<UUID, Set<Position3D>> {
+    private fun displayComplete(playerId: UUID, playerState: PlayerState, playerPosition: Position3D): Map<UUID, Set<Position3D>> {
         val chunkPosition = Position2D(floor(playerPosition.x / 16.0).toInt(), floor(playerPosition.z / 16.0).toInt())
         val chunks = getSurroundingChunks(chunkPosition, 16) // View distance fixed for now
         val partitions = chunks.flatMap { partitionRepository.getByChunk(it) }.toSet()
@@ -76,7 +76,9 @@ class DisplayVisualisation(private val playerStateRepository: PlayerStateReposit
 
             // Handle claim not owned by this player
             if (claim.playerId != playerId) {
-                visualised[claim.id] = handleNonOwnedClaimDisplay(playerId, claim).toMutableSet()
+                visualised[claim.id] = handleNonOwnedClaimDisplay(playerId, claim).filter {
+                    it != playerState.selectedBlock }
+                    .toSet()
             } else {
                 // Get all partitions linked to found claim
                 val partitions = partitionRepository.getByClaim(claim.id)
@@ -84,7 +86,10 @@ class DisplayVisualisation(private val playerStateRepository: PlayerStateReposit
 
                 // Visualise the entire claim border and map it
                 visualised[claim.id] = visualisationService.displayComplete(playerId, areas,
-                    "LIGHT_BLUE_GLAZED_TERRACOTTA", "LIGHT_GRAY_CARPET")
+                    "LIGHT_BLUE_GLAZED_TERRACOTTA", "LIGHT_GRAY_CARPET").filter {
+                        it != playerState.selectedBlock }
+                    .toSet()
+
             }
         }
         return visualised
@@ -93,7 +98,7 @@ class DisplayVisualisation(private val playerStateRepository: PlayerStateReposit
     /**
      * Visualise a player's claims with individual partitions shown.
      */
-    private fun displayPartitioned(playerId: UUID, playerPosition: Position3D): Map<UUID, Set<Position3D>> {
+    private fun displayPartitioned(playerId: UUID, playerState: PlayerState, playerPosition: Position3D): Map<UUID, Set<Position3D>> {
         val chunkPosition = Position2D(floor(playerPosition.x / 16.0).toInt(), floor(playerPosition.z / 16.0).toInt())
         val chunks = getSurroundingChunks(chunkPosition, 16) // View distance fixed for now
         val partitions = chunks.flatMap { partitionRepository.getByChunk(it) }.toSet()
@@ -114,12 +119,16 @@ class DisplayVisualisation(private val playerStateRepository: PlayerStateReposit
                 // Main partition
                 visualisationService.displayPartitioned(playerId, setOf(partition.area),
                     "CYAN_GLAZED_TERRACOTTA", "CYAN_CARPET",
-                    "BLUE_GLAZED_TERRACOTTA", "BLUE_CARPET")
+                    "BLUE_GLAZED_TERRACOTTA", "BLUE_CARPET").filter {
+                    it != playerState.selectedBlock }
+                    .toSet()
             } else {
                 // Attached partitions
                 visualisationService.displayPartitioned(playerId, setOf(partition.area),
                     "LIGHT_GRAY_GLAZED_TERRACOTTA", "LIGHT_GRAY_CARPET",
-                    "LIGHT_BLUE_GLAZED_TERRACOTTA", "LIGHT_BLUE_CARPET")
+                    "LIGHT_BLUE_GLAZED_TERRACOTTA", "LIGHT_BLUE_CARPET").filter {
+                    it != playerState.selectedBlock }
+                    .toSet()
             }
 
             visualised.computeIfAbsent(claim.id) { mutableSetOf() }.addAll(newPositions)

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/ScheduleClearVisualisation.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/ScheduleClearVisualisation.kt
@@ -10,6 +10,7 @@ import java.util.UUID
 class ScheduleClearVisualisation(private val playerStateRepository: PlayerStateRepository,
                                  private val schedulerService: SchedulerService,
                                  private val clearVisualisation: ClearVisualisation,
+                                 private val clearSelectionVisualisation: ClearSelectionVisualisation,
                                  private val config: MainConfig) {
     fun execute(playerId: UUID): ScheduleClearVisualisationResult {
         // Get or create player state if it doesn't exist
@@ -27,7 +28,10 @@ class ScheduleClearVisualisation(private val playerStateRepository: PlayerStateR
         if (playerState.isVisualisingClaims) {
             playerState.isVisualisingClaims = false
             val delayTicks = (20L * config.visualiserHideDelayPeriod).toLong()
-            val task = schedulerService.schedule(delayTicks) { clearVisualisation.execute(playerId) }
+            val task = schedulerService.schedule(delayTicks) {
+                clearVisualisation.execute(playerId)
+                clearSelectionVisualisation.execute(playerId)
+            }
             playerState.scheduledVisualiserHide = task
             return ScheduleClearVisualisationResult.Success
         } else {

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/services/VisualisationService.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/services/VisualisationService.kt
@@ -5,6 +5,7 @@ import dev.mizarc.bellclaims.domain.values.Position3D
 import java.util.UUID
 
 interface VisualisationService {
+    fun displaySelected(playerId: UUID, position: Position3D, block: String, surfaceBlock: String): Set<Position3D>
     fun displayComplete(playerId: UUID, areas: Set<Area>, edgeBlock: String, edgeSurfaceBlock: String): Set<Position3D>
     fun displayPartitioned(playerId: UUID, areas: Set<Area>, edgeBlock: String, edgeSurfaceBlock: String,
                            cornerBlock: String, cornerSurfaceBlock: String): Set<Position3D>

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/services/VisualisationService.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/services/VisualisationService.kt
@@ -5,7 +5,7 @@ import dev.mizarc.bellclaims.domain.values.Position3D
 import java.util.UUID
 
 interface VisualisationService {
-    fun displaySelected(playerId: UUID, position: Position3D, block: String, surfaceBlock: String): Set<Position3D>
+    fun displaySelected(playerId: UUID, position: Position3D, block: String, surfaceBlock: String)
     fun displayComplete(playerId: UUID, areas: Set<Area>, edgeBlock: String, edgeSurfaceBlock: String): Set<Position3D>
     fun displayPartitioned(playerId: UUID, areas: Set<Area>, edgeBlock: String, edgeSurfaceBlock: String,
                            cornerBlock: String, cornerSurfaceBlock: String): Set<Position3D>

--- a/src/main/kotlin/dev/mizarc/bellclaims/di/Modules.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/di/Modules.kt
@@ -55,7 +55,9 @@ import dev.mizarc.bellclaims.application.actions.player.tool.GivePlayerMoveTool
 import dev.mizarc.bellclaims.application.actions.player.tool.IsItemClaimTool
 import dev.mizarc.bellclaims.application.actions.player.tool.IsItemMoveTool
 import dev.mizarc.bellclaims.application.actions.player.tool.SyncToolVisualization
+import dev.mizarc.bellclaims.application.actions.player.visualisation.ClearSelectionVisualisation
 import dev.mizarc.bellclaims.application.actions.player.visualisation.ClearVisualisation
+import dev.mizarc.bellclaims.application.actions.player.visualisation.DisplaySelectionVisualisation
 import dev.mizarc.bellclaims.application.actions.player.visualisation.DisplayVisualisation
 import dev.mizarc.bellclaims.application.actions.player.visualisation.GetVisualisedClaimBlocks
 import dev.mizarc.bellclaims.application.actions.player.visualisation.GetVisualiserMode
@@ -215,7 +217,9 @@ fun appModule(plugin: BellClaims) = module {
     singleOf(::SyncToolVisualization)
 
     // Player / Visualisation
+    singleOf(::ClearSelectionVisualisation)
     singleOf(::ClearVisualisation)
+    singleOf(::DisplaySelectionVisualisation)
     singleOf(::DisplayVisualisation)
     singleOf(::GetVisualisedClaimBlocks)
     singleOf(::GetVisualiserMode)

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/entities/PlayerState.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/entities/PlayerState.kt
@@ -25,4 +25,7 @@ class PlayerState(val playerId: UUID) {
 
     // Map claim id to partition id to block positions
     var visualisedPartitions: MutableMap<UUID, MutableMap<UUID, Set<Position3D>>> = mutableMapOf()
+
+    // Save the block the player has currently selected by the claim tool
+    var selectedBlock: Position3D? = null
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/values/LocalizationKeys.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/values/LocalizationKeys.kt
@@ -37,6 +37,8 @@ object LocalizationKeys {
     const val FEEDBACK_EDIT_TOOL_TOO_CLOSE = "feedback.edit_tool.too_close"
     const val FEEDBACK_EDIT_TOOL_UNEQUIP_BUILD = "feedback.edit_tool.unequip_build"
     const val FEEDBACK_EDIT_TOOL_UNEQUIP_RESIZE = "feedback.edit_tool.unequip_resize"
+    const val FEEDBACK_EDIT_TOOL_UNSELECT_BUILD = "feedback.edit_tool.unselect_build"
+    const val FEEDBACK_EDIT_TOOL_UNSELECT_RESIZE = "feedback.edit_tool.unselect_resize"
 
     // Move Tool
     const val FEEDBACK_MOVE_TOOL_SUCCESS = "feedback.move_tool.success"

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/VisualisationServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/VisualisationServiceBukkit.kt
@@ -27,8 +27,18 @@ class VisualisationServiceBukkit: VisualisationService {
         West
     }
 
+    override fun displaySelected(
+        playerId: UUID,
+        position: Position3D,
+        block: String,
+        surfaceBlock: String
+    ) {
+        val player = Bukkit.getPlayer(playerId) ?: return
+        setVisualisedBlock(player, position, Material.valueOf(block), Material.valueOf(surfaceBlock))
+    }
+
     /**
-     * Visualise a claim with only the outer borders shown.
+     * Visualize a claim with only the outer borders shown.
      */
     override fun displayComplete(playerId: UUID, areas: Set<Area>, edgeBlock: String,
                                  edgeSurfaceBlock: String): Set<Position3D> {

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolListener.kt
@@ -7,6 +7,8 @@ import dev.mizarc.bellclaims.application.actions.claim.partition.ResizePartition
 import dev.mizarc.bellclaims.application.actions.player.DoesPlayerHaveClaimOverride
 import dev.mizarc.bellclaims.application.actions.player.GetRemainingClaimBlockCount
 import dev.mizarc.bellclaims.application.actions.player.tool.IsItemClaimTool
+import dev.mizarc.bellclaims.application.actions.player.visualisation.ClearSelectionVisualisation
+import dev.mizarc.bellclaims.application.actions.player.visualisation.DisplaySelectionVisualisation
 import dev.mizarc.bellclaims.application.actions.player.visualisation.DisplayVisualisation
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.TextColor
@@ -36,6 +38,7 @@ import dev.mizarc.bellclaims.interaction.menus.MenuNavigator
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.util.UUID
+import kotlin.concurrent.thread
 
 /**
  * Actions based on utilizing the claim tool.
@@ -50,6 +53,8 @@ class EditToolListener: Listener, KoinComponent {
     private val doesPlayerHaveClaimOverride: DoesPlayerHaveClaimOverride by inject()
     private val resizePartition: ResizePartition by inject()
     private val isItemClaimTool: IsItemClaimTool by inject()
+    private val displaySelectionVisualisation: DisplaySelectionVisualisation by inject()
+    private val clearSelectionVisualisation: ClearSelectionVisualisation by inject()
 
     // Map of player id to the partition and the first selected corner to resize a partition
     private val firstSelectedCornerResize: MutableMap<UUID, Pair<UUID, Position2D>> = mutableMapOf()
@@ -169,6 +174,10 @@ class EditToolListener: Listener, KoinComponent {
 
         // Start partition building
         firstSelectedCornerCreate[player.uniqueId] = Pair(selectedClaim.id, location.toPosition2D())
+        thread(start = true) {
+            Thread.sleep(1)
+            displaySelectionVisualisation.execute(player.uniqueId, location.toPosition3D())
+        }
         return player.sendActionBar(
             Component.text(localizationProvider.get(
                 player.uniqueId, LocalizationKeys.FEEDBACK_EDIT_TOOL_START_EXTENSION,
@@ -257,6 +266,10 @@ class EditToolListener: Listener, KoinComponent {
             Component.text(localizationProvider.get(
                 player.uniqueId, LocalizationKeys.FEEDBACK_EDIT_TOOL_START_RESIZE, remainingClaimBlockCount))
                 .color(TextColor.color(85, 255, 85)))
+        thread(start = true) {
+            Thread.sleep(1)
+            displaySelectionVisualisation.execute(player.uniqueId, location.toPosition3D())
+        }
         return true
     }
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolListener.kt
@@ -83,8 +83,6 @@ class EditToolListener: Listener, KoinComponent {
             return
         }
 
-        displayVisualisation.execute(event.player.uniqueId, event.player.location.toPosition3D())
-
         // Resizes an existing partition
         val partitionResizer = firstSelectedCornerResize[event.player.uniqueId]
         if (partitionResizer != null) {
@@ -166,6 +164,7 @@ class EditToolListener: Listener, KoinComponent {
                 Component.text(localizationProvider.get(
                     player.uniqueId, LocalizationKeys.FEEDBACK_EDIT_TOOL_INVALID))
                     .color(TextColor.color(255, 85, 85)))
+            visualise(player)
             return
         }
 
@@ -193,6 +192,7 @@ class EditToolListener: Listener, KoinComponent {
 
         // Check if selection exists next to any of the player's owned claims
         if (selectedClaim == null) {
+            visualise(player)
             return player.sendActionBar(
                 Component.text(localizationProvider.get(
                     player.uniqueId, LocalizationKeys.FEEDBACK_EDIT_TOOL_INVALID))
@@ -243,6 +243,8 @@ class EditToolListener: Listener, KoinComponent {
                             )
                                 .color(TextColor.color(85, 255, 85))
                         )
+                        clearSelectionVisualisation.execute(player.uniqueId)
+                        visualise(player)
                         firstSelectedCornerCreate.remove(player.uniqueId)
                         val event = PartitionModificationEvent(result.partition)
                         event.callEvent()
@@ -390,6 +392,8 @@ class EditToolListener: Listener, KoinComponent {
                                     .color(TextColor.color(85, 255, 85)))
                             val event = PartitionModificationEvent(result.partition)
                             event.callEvent()
+                            clearSelectionVisualisation.execute(player.uniqueId)
+                            visualise(player)
                             firstSelectedCornerResize.remove(player.uniqueId)
                         }
                 }
@@ -477,5 +481,9 @@ class EditToolListener: Listener, KoinComponent {
                 else -> null
             }
         }
+    }
+
+    private fun visualise(player: Player) {
+        displayVisualisation.execute(player.uniqueId, player.location.toPosition3D())
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolListener.kt
@@ -83,6 +83,16 @@ class EditToolListener: Listener, KoinComponent {
         // Resizes an existing partition
         val partitionResizer = firstSelectedCornerResize[event.player.uniqueId]
         if (partitionResizer != null) {
+            if (partitionResizer.second == clickedBlock.location.toPosition2D()) {
+                clearSelectionVisualisation.execute(event.player.uniqueId)
+                firstSelectedCornerResize.remove(event.player.uniqueId)
+                event.player.sendActionBar(
+                    Component.text(localizationProvider.get(
+                        event.player.uniqueId, LocalizationKeys.FEEDBACK_EDIT_TOOL_UNSELECT_RESIZE))
+                        .color(TextColor.color(255, 85, 85)))
+                return
+            }
+
             resizePartitionBranch(event.player, clickedBlock.location, partitionResizer)
             return
         }
@@ -90,6 +100,16 @@ class EditToolListener: Listener, KoinComponent {
         // Creates a new partition
         val partitionBuilder = firstSelectedCornerCreate[event.player.uniqueId]
         if (partitionBuilder != null) {
+            if (partitionBuilder.second == clickedBlock.location.toPosition2D()) {
+                clearSelectionVisualisation.execute(event.player.uniqueId)
+                firstSelectedCornerCreate.remove(event.player.uniqueId)
+                event.player.sendActionBar(
+                    Component.text(localizationProvider.get(
+                        event.player.uniqueId, LocalizationKeys.FEEDBACK_EDIT_TOOL_UNSELECT_BUILD))
+                        .color(TextColor.color(255, 85, 85)))
+                return
+            }
+
             createPartitionBranch(event.player, clickedBlock.location, partitionBuilder)
             return
         }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolVisualisingListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolVisualisingListener.kt
@@ -54,16 +54,6 @@ class EditToolVisualisingListener(private val plugin: JavaPlugin): Listener, Koi
         plugin.server.scheduler.runTask(plugin, Runnable { handleAutoVisualisation(player) })
     }
 
-    /**
-     * Triggers when the player clicks on a border block while visualisation is active.
-     */
-    @EventHandler
-    fun onClaimToolClick(event: PlayerInteractEvent) {
-        thread(start = true) {
-            Thread.sleep(1)
-            handleAutoVisualisation(event.player)
-        }
-    }
 
     /**
      * Visualise if player isn't already holding the claim tool (e.g. swapping hands)

--- a/src/main/resources/lang/defaults/en.properties
+++ b/src/main/resources/lang/defaults/en.properties
@@ -34,6 +34,8 @@ feedback_edit_tool.successful_resize=Partition successfully resized. You have {0
 feedback.edit_tool.too_close=That selection is too close to another claim
 feedback.edit_tool.unequip_build=Claim tool unequipped. Claim building has been cancelled
 feedback.edit_tool.unequip_resize=Claim tool unequipped. Claim resizing has been cancelled
+feedback.edit_tool.unselect_build=Block unselected. Claim building has been cancelled
+feedback.edit_tool.unselect_resize=Block unselected. Claim resizing has been cancelled
 
 # Destruction
 feedback.destruction.attached=That block is attached to the claim bell


### PR DESCRIPTION
This green block lets people know that they've selected the block instead of just telling them in the action bar. Various other bug fixes included to prevent flickering and complete break down when using partition visualisation mode.