### PR TITLE
Prevent claim from being created over world border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ New major beta feature drop! Quality of life changes all around and support for 
 - Leaf litter is now included in the transparency block filter.
 - A new block now indicates the actively selected block while editing partitions.
 - The current partition resize or add operation can be canceled by clicking on the actively selected block.
+- Trying to create a claim too close to the world border is now blocked to prevent the partition from going across the border.
 
 ### Changed
 - Using bone meal on crops is now covered by the harvest permission. The build permission still covers bone meal usage on non-crops.
@@ -36,6 +37,7 @@ New major beta feature drop! Quality of life changes all around and support for 
 - Using custom Anvil GUIs may define location as (0, 0, 0), which blocks players from opening menus if a claim exists at (0, 0)
 - Bell being duplicated when using the move tool.
 - The Main partition isn't correctly indicated by the main partition visualizer blocks.
+- Floating point error on claim creation causing partitions to generate with unusual sizes when far from the world center.
 
 ## [0.3.7]
 This is a version bump only release. Update to support MC version 1.21.3.

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/CreateClaim.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/CreateClaim.kt
@@ -39,10 +39,13 @@ class CreateClaim(private val claimRepository: ClaimRepository, private val part
         }
 
         // Generates the partition area based on config
-        val halfSize = (config.initialClaimSize.toFloat() - 1) / 2
+        val areaSize = config.initialClaimSize
+        val offsetMin = (areaSize - 1) / 2
+        val offsetMax = areaSize / 2
         val area = Area(
-            Position2D((position3D.x - floor(halfSize)).toInt(), (position3D.z - floor(halfSize)).toInt()),
-            Position2D((position3D.x + ceil(halfSize)).toInt(),(position3D.z + ceil(halfSize)).toInt()))
+            Position2D(position3D.x - offsetMin, position3D.z - offsetMin),
+            Position2D(position3D.x + offsetMax, position3D.z + offsetMax)
+        )
 
         // Validate area is within world border
         if (!worldManipulationService.isInsideWorldBorder(worldId, area)) {

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/IsNewClaimLocationValid.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/IsNewClaimLocationValid.kt
@@ -3,6 +3,7 @@ package dev.mizarc.bellclaims.application.actions.claim
 import dev.mizarc.bellclaims.application.persistence.ClaimRepository
 import dev.mizarc.bellclaims.application.persistence.PartitionRepository
 import dev.mizarc.bellclaims.application.results.claim.IsNewClaimLocationValidResult
+import dev.mizarc.bellclaims.application.services.WorldManipulationService
 import dev.mizarc.bellclaims.config.MainConfig
 import dev.mizarc.bellclaims.domain.entities.Partition
 import dev.mizarc.bellclaims.domain.values.Area
@@ -13,7 +14,9 @@ import kotlin.math.ceil
 import kotlin.math.floor
 
 class IsNewClaimLocationValid(private val claimRepository: ClaimRepository,
-                              private val partitionRepository: PartitionRepository, private val config: MainConfig) {
+                              private val partitionRepository: PartitionRepository,
+                              private val worldManipulationService: WorldManipulationService,
+                              private val config: MainConfig) {
     fun execute(position: Position, worldId: UUID): IsNewClaimLocationValidResult {
         // Create the area that is required for the partition
         val halfSize = (config.initialClaimSize.toFloat() - 1) / 2
@@ -37,6 +40,12 @@ class IsNewClaimLocationValid(private val claimRepository: ClaimRepository,
                 return IsNewClaimLocationValidResult.Overlap
             }
         }
+
+        // Validate area is within world border
+        if (!worldManipulationService.isInsideWorldBorder(worldId, areaWithBoundary)) {
+            return IsNewClaimLocationValidResult.TooCloseToWorldBorder
+        }
+
         return IsNewClaimLocationValidResult.Valid
     }
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/IsNewClaimLocationValid.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/IsNewClaimLocationValid.kt
@@ -19,10 +19,13 @@ class IsNewClaimLocationValid(private val claimRepository: ClaimRepository,
                               private val config: MainConfig) {
     fun execute(position: Position, worldId: UUID): IsNewClaimLocationValidResult {
         // Create the area that is required for the partition
-        val halfSize = (config.initialClaimSize.toFloat() - 1) / 2
+        val initialClaimSize = config.initialClaimSize
+        val offsetMin = (initialClaimSize - 1) / 2
+        val offsetMax = initialClaimSize / 2
         val area = Area(
-            Position2D((position.x - floor(halfSize)).toInt(), (position.z - floor(halfSize)).toInt()),
-            Position2D((position.x + ceil(halfSize)).toInt(), (position.z + ceil(halfSize)).toInt()))
+            Position2D(position.x - offsetMin, position.z - offsetMin),
+            Position2D(position.x + offsetMax, position.z + offsetMax)
+        )
 
         // Get the partitions that exist in the occupied chunk space
         val chunks = area.getChunks().flatMap { getSurroundingPositions(it, 1) }

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/results/claim/CreateClaimResult.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/results/claim/CreateClaimResult.kt
@@ -7,4 +7,5 @@ sealed class CreateClaimResult {
     object NameCannotBeBlank: CreateClaimResult()
     object LimitExceeded: CreateClaimResult()
     object NameAlreadyExists: CreateClaimResult()
+    object TooCloseToWorldBorder: CreateClaimResult()
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/results/claim/IsNewClaimLocationValidResult.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/results/claim/IsNewClaimLocationValidResult.kt
@@ -4,6 +4,6 @@ sealed class IsNewClaimLocationValidResult {
     object Valid: IsNewClaimLocationValidResult()
     object Overlap: IsNewClaimLocationValidResult()
     object TooClose: IsNewClaimLocationValidResult()
-    object OutsideWorldBorder: IsNewClaimLocationValidResult()
+    object TooCloseToWorldBorder: IsNewClaimLocationValidResult()
     object StorageError: IsNewClaimLocationValidResult()
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/services/WorldManipulationService.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/services/WorldManipulationService.kt
@@ -1,8 +1,10 @@
 package dev.mizarc.bellclaims.application.services
 
+import dev.mizarc.bellclaims.domain.values.Area
 import dev.mizarc.bellclaims.domain.values.Position3D
 import java.util.UUID
 
 interface WorldManipulationService {
     fun breakWithoutItemDrop(worldId: UUID, position: Position3D): Boolean
+    fun isInsideWorldBorder(worldId: UUID, area: Area): Boolean
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/values/LocalizationKeys.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/values/LocalizationKeys.kt
@@ -64,6 +64,7 @@ object LocalizationKeys {
     const val CREATION_CONDITION_EXISTING = "creation_condition.existing"
     const val CREATION_CONDITION_OVERLAP = "creation_condition.overlap"
     const val CREATION_CONDITION_UNNAMED = "creation_condition.unnamed"
+    const val CREATION_CONDITION_WORLD_BORDER = "creation_condition.world_border"
 
     // Transfer Conditions
     const val SEND_TRANSFER_CONDITION_BLOCKS = "send_transfer_condition.blocks"

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/WorldManipulationServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/WorldManipulationServiceBukkit.kt
@@ -1,17 +1,43 @@
 package dev.mizarc.bellclaims.infrastructure.services
 
 import dev.mizarc.bellclaims.application.services.WorldManipulationService
+import dev.mizarc.bellclaims.domain.values.Area
 import dev.mizarc.bellclaims.domain.values.Position3D
 import dev.mizarc.bellclaims.infrastructure.adapters.bukkit.toLocation
 import org.bukkit.Bukkit
 import org.bukkit.Material
 import java.util.UUID
 
-class WorldManipulationServiceBukkit: WorldManipulationService {
+class WorldManipulationServiceBukkit : WorldManipulationService {
     override fun breakWithoutItemDrop(worldId: UUID, position: Position3D): Boolean {
         val world = Bukkit.getWorld(worldId) ?: return false
         val block = world.getBlockAt(position.toLocation(world))
         block.type = Material.AIR
         return true
+    }
+
+    override fun isInsideWorldBorder(worldId: UUID, area: Area): Boolean {
+        val world = Bukkit.getWorld(worldId) ?: return true
+        val worldBorder = world.worldBorder
+        val center = worldBorder.center
+        val radius = worldBorder.size / 2
+
+        val borderMinX = center.x - radius
+        val borderMaxX = center.x + radius
+        val borderMinZ = center.z - radius
+        val borderMaxZ = center.z + radius
+
+        val areaMinX = area.lowerPosition2D.x.toDouble()
+        val areaMaxX = area.upperPosition2D.x.toDouble()
+        val areaMinZ = area.lowerPosition2D.z.toDouble()
+        val areaMaxZ = area.upperPosition2D.z.toDouble()
+
+        val isContained =
+            areaMinX >= borderMinX &&
+                    areaMaxX <= borderMaxX &&
+                    areaMinZ >= borderMinZ &&
+                    areaMaxZ <= borderMaxZ
+
+        return isContained
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/management/ClaimCreationMenu.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/management/ClaimCreationMenu.kt
@@ -74,6 +74,15 @@ class ClaimCreationMenu(private val player: Player, private val menuNavigator: M
                 gui.show(player)
                 return
             }
+            IsNewClaimLocationValidResult.TooCloseToWorldBorder -> {
+                val iconEditorItem = ItemStack(Material.MAGMA_CREAM)
+                    .name(localizationProvider.get(playerId, LocalizationKeys.MENU_CREATION_ITEM_CANNOT_CREATE_NAME))
+                    .lore(localizationProvider.get(playerId, LocalizationKeys.CREATION_CONDITION_WORLD_BORDER))
+                val guiIconEditorItem = GuiItem(iconEditorItem) { guiEvent -> guiEvent.isCancelled = true }
+                pane.addItem(guiIconEditorItem, 4, 0)
+                gui.show(player)
+                return
+            }
             IsNewClaimLocationValidResult.StorageError ->
                 player.sendMessage(localizationProvider.get(playerId, LocalizationKeys.GENERAL_ERROR))
             else ->

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/management/ClaimNamingMenu.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/management/ClaimNamingMenu.kt
@@ -119,6 +119,19 @@ class ClaimNamingMenu(private val player: Player, private val menuNavigator: Men
                     bellItem.name("")
                     gui.update()
                 }
+                is CreateClaimResult.TooCloseToWorldBorder -> {
+                    val paperItem = ItemStack(Material.PAPER)
+                        .name(localizationProvider.get(playerId, LocalizationKeys.CREATION_CONDITION_WORLD_BORDER))
+                    val guiPaperItem = GuiItem(paperItem) { guiEvent ->
+                        secondPane.removeItem(0, 0)
+                        bellItem.name(name)
+                        isConfirming = true
+                        gui.update()
+                    }
+                    secondPane.addItem(guiPaperItem, 0, 0)
+                    bellItem.name(name)
+                    gui.update()
+                }
             }
         }
 

--- a/src/main/resources/lang/defaults/en.properties
+++ b/src/main/resources/lang/defaults/en.properties
@@ -67,6 +67,7 @@ creation_condition.claims=You have run out of claims.
 creation_condition.existing=You already have a claim with that name.
 creation_condition.overlap=The resulting claim would overlap another claim.
 creation_condition.unnamed=Name cannot be blank.
+creation_condition.world_border=Too close to the world border to establish a claim.
 
 # Send Transfer Conditions
 send_transfer_condition.blocks=Player has insufficient claim blocks.


### PR DESCRIPTION
If the claim is too close to the world border and would result in the partition being outside of the border, the claim creation is blocked. This also solves a bug where partitions are oddly shaped when far away from world spawn due to floating point rounding issue.