### PR TITLE
Enhance visualiser to always display corners in all modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ## [0.4.1]
 
 ### Changed
-- Complete visualizer render displays selectable corner blocks
-- Visualizer carpet displays the matching color for the type of terracotta it's overlaying
+- Complete visualizer render displays selectable corner blocks.
+- Visualizer carpet displays the matching color for the type of terracotta it's overlaying.
+- All selectable visualiser corners are now blue regardless of mode.
 
 ## [0.4.0]
 New major beta feature drop! Quality of life changes all around and support for 1.21.5.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [0.4.1]
+
+### Changed
+- Complete visualizer render displays selectable corner blocks
+- Visualizer carpet displays the matching color for the type of terracotta it's overlaying
+
 ## [0.4.0]
 New major beta feature drop! Quality of life changes all around and support for 1.21.5.
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/DisplayVisualisation.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/DisplayVisualisation.kt
@@ -129,7 +129,7 @@ class DisplayVisualisation(private val playerStateRepository: PlayerStateReposit
                 // Attached partitions
                 visualisationService.displayPartitioned(playerId, setOf(partition.area),
                     "LIGHT_GRAY_GLAZED_TERRACOTTA", "LIGHT_GRAY_CARPET",
-                    "LIGHT_BLUE_GLAZED_TERRACOTTA", "LIGHT_BLUE_CARPET").filter {
+                    "BLUE_GLAZED_TERRACOTTA", "BLUE_CARPET").filter {
                     it != playerState.selectedBlock }
                     .toSet()
             }

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/DisplayVisualisation.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/DisplayVisualisation.kt
@@ -86,7 +86,7 @@ class DisplayVisualisation(private val playerStateRepository: PlayerStateReposit
 
                 // Visualise the entire claim border and map it
                 visualised[claim.id] = visualisationService.displayComplete(playerId, areas,
-                    "LIGHT_BLUE_GLAZED_TERRACOTTA", "LIGHT_GRAY_CARPET").filter {
+                    "LIGHT_BLUE_GLAZED_TERRACOTTA", "LIGHT_BLUE_CARPET", "BLUE_GLAZED_TERRACOTTA", "BLUE_CARPET").filter {
                         it != playerState.selectedBlock }
                     .toSet()
 
@@ -144,7 +144,7 @@ class DisplayVisualisation(private val playerStateRepository: PlayerStateReposit
         // Get all partitions linked to found claim
         val partitions = partitionRepository.getByClaim(claim.id)
         val areas = partitions.map { it.area }.toMutableSet()
-        return visualisationService.displayComplete(playerId, areas, "RED_GLAZED_TERRACOTTA", "LIGHT_GRAY_CARPET")
+        return visualisationService.displayComplete(playerId, areas, "RED_GLAZED_TERRACOTTA", "RED_CARPET", "BLACK_GLAZED_TERRACOTTA", "BLACK_CARPET")
     }
     
     /**

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/RefreshVisualisation.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/RefreshVisualisation.kt
@@ -45,9 +45,9 @@ class RefreshVisualisation(private val playerStateRepository: PlayerStateReposit
             playerState.visualisedPartitions[claimId]?.get(partitionId)
             val visualisedPositions = playerState.visualisedPartitions[claimId]?.get(partitionId)
             if (visualisedPositions == null) {
-                val newPositions =visualisationService.refreshPartitioned(playerId, emptySet(), setOf(partition.area),
+                val newPositions = visualisationService.refreshPartitioned(playerId, emptySet(), setOf(partition.area),
                     "LIGHT_GRAY_GLAZED_TERRACOTTA", "LIGHT_GRAY_CARPET",
-                    "LIGHT_BLUE_GLAZED_TERRACOTTA", "LIGHT_BLUE_CARPET")
+                    "BLUE_GLAZED_TERRACOTTA", "BLUE_CARPET")
                 playerState.visualisedPartitions.computeIfAbsent(claim.id) { mutableMapOf() }[partition.id] = newPositions
             } else {
                 val newPositions = if (partition.area.isPositionInArea(claim.position)) {
@@ -59,7 +59,7 @@ class RefreshVisualisation(private val playerStateRepository: PlayerStateReposit
                     // Attached partitions
                     visualisationService.refreshPartitioned(playerId, visualisedPositions, setOf(partition.area),
                         "LIGHT_GRAY_GLAZED_TERRACOTTA", "LIGHT_GRAY_CARPET",
-                        "LIGHT_BLUE_GLAZED_TERRACOTTA", "LIGHT_BLUE_CARPET")
+                        "BLUE_GLAZED_TERRACOTTA", "BLUE_CARPET")
                 }
                 playerState.visualisedPartitions.computeIfAbsent(claim.id) { mutableMapOf() }[partition.id] = newPositions
             }

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/RefreshVisualisation.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/RefreshVisualisation.kt
@@ -27,7 +27,7 @@ class RefreshVisualisation(private val playerStateRepository: PlayerStateReposit
             val partitions = partitionRepository.getByClaim(claim.id)
             val areas = partitions.map { it.area }.toMutableSet()
             val newPositions = visualisationService.refreshComplete(playerId, visualisedPositions, areas,
-                "RED_GLAZED_TERRACOTTA", "LIGHT_GRAY_CARPET")
+                "RED_GLAZED_TERRACOTTA", "RED_CARPET", "BLACK_GLAZED_TERRACOTTA", "BLACK_CARPET")
             playerState.visualisedClaims[claimId] = newPositions
             return
         }
@@ -70,7 +70,7 @@ class RefreshVisualisation(private val playerStateRepository: PlayerStateReposit
             val partitions = partitionRepository.getByClaim(claim.id)
             val areas = partitions.map { it.area }.toMutableSet()
             val newPositions = visualisationService.refreshComplete(playerId, visualisedPositions, areas,
-                "LIGHT_BLUE_GLAZED_TERRACOTTA", "LIGHT_GRAY_CARPET")
+                "LIGHT_BLUE_GLAZED_TERRACOTTA", "LIGHT_BLUE_CARPET", "BLUE_GLAZED_TERRACOTTA", "BLUE_CARPET")
             playerState.visualisedClaims[claimId] = newPositions
             return
         }

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/services/VisualisationService.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/services/VisualisationService.kt
@@ -6,11 +6,12 @@ import java.util.UUID
 
 interface VisualisationService {
     fun displaySelected(playerId: UUID, position: Position3D, block: String, surfaceBlock: String)
-    fun displayComplete(playerId: UUID, areas: Set<Area>, edgeBlock: String, edgeSurfaceBlock: String): Set<Position3D>
+    fun displayComplete(playerId: UUID, areas: Set<Area>, edgeBlock: String, edgeSurfaceBlock: String,
+                        cornerBlock: String, cornerSurfaceBlock: String): Set<Position3D>
     fun displayPartitioned(playerId: UUID, areas: Set<Area>, edgeBlock: String, edgeSurfaceBlock: String,
                            cornerBlock: String, cornerSurfaceBlock: String): Set<Position3D>
     fun refreshComplete(playerId: UUID, existingPositions: Set<Position3D>, areas: Set<Area>,
-                        edgeBlock: String, edgeSurfaceBlock: String): Set<Position3D>
+                        edgeBlock: String, edgeSurfaceBlock: String, cornerBlock: String, cornerSurfaceBlock: String): Set<Position3D>
     fun refreshPartitioned(playerId: UUID, existingPositions: Set<Position3D>, areas: Set<Area>, edgeBlock: String,
                            edgeSurfaceBlock: String, cornerBlock: String, cornerSurfaceBlock: String): Set<Position3D>
     fun clear(playerId: UUID, areas: Set<Position3D>)

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/VisualisationServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/VisualisationServiceBukkit.kt
@@ -51,7 +51,7 @@ class VisualisationServiceBukkit: VisualisationService {
         val corners = get3DPartitionedCorners(areas, player.location)
         setVisualisedBlocks(player, borders, Material.valueOf(edgeBlock), Material.valueOf(edgeSurfaceBlock))
         setVisualisedBlocks(player, corners, Material.valueOf(cornerBlock), Material.valueOf(cornerSurfaceBlock))
-        return borders
+        return (borders + corners)
     }
 
     /**

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/VisualisationServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/VisualisationServiceBukkit.kt
@@ -41,13 +41,16 @@ class VisualisationServiceBukkit: VisualisationService {
      * Visualize a claim with only the outer borders shown.
      */
     override fun displayComplete(playerId: UUID, areas: Set<Area>, edgeBlock: String,
-                                 edgeSurfaceBlock: String): Set<Position3D> {
+                                 edgeSurfaceBlock: String, cornerBlock: String,
+                                 cornerSurfaceBlock: String): Set<Position3D> {
         // Get player if they exist
         val player = Bukkit.getPlayer(playerId) ?: return emptySet()
 
         // Get positions and set visualisations on blocks
         val borders = get3DOuterBorders(areas, player.location)
+        val corners = get3DPartitionedCorners(areas, player.location)
         setVisualisedBlocks(player, borders, Material.valueOf(edgeBlock), Material.valueOf(edgeSurfaceBlock))
+        setVisualisedBlocks(player, corners, Material.valueOf(cornerBlock), Material.valueOf(cornerSurfaceBlock))
         return borders
     }
 
@@ -71,8 +74,9 @@ class VisualisationServiceBukkit: VisualisationService {
     }
 
     override fun refreshComplete(playerId: UUID, existingPositions: Set<Position3D>, areas: Set<Area>,
-                                 edgeBlock: String, edgeSurfaceBlock: String): Set<Position3D> {
-        val border = displayComplete(playerId, areas, edgeBlock, edgeSurfaceBlock)
+                                 edgeBlock: String, edgeSurfaceBlock: String, cornerBlock: String,
+                                 cornerSurfaceBlock: String): Set<Position3D> {
+        val border = displayComplete(playerId, areas, edgeBlock, edgeSurfaceBlock, cornerBlock, cornerSurfaceBlock)
         val borderToRemove = existingPositions.toMutableSet()
         borderToRemove.removeAll(border)
         clear(playerId, borderToRemove)


### PR DESCRIPTION
Corners are now displayed in visualiser regardless of view or edit mode. Corner colours are now standardised to just blue regardless of visualiser mode.