### PR TITLE
Always allow riding mobs in claims

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,10 +33,10 @@ repositories {
 dependencies {
     testImplementation(kotlin("test"))
     testImplementation("io.mockk:mockk:1.13.11")
-    testImplementation("io.papermc.paper:paper-api:1.21.5-R0.1-SNAPSHOT")
+    testImplementation("io.papermc.paper:paper-api:1.21.8-R0.1-SNAPSHOT")
     testImplementation("com.github.MilkBowl:VaultAPI:1.7")
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
-    compileOnly("io.papermc.paper:paper-api:1.21.5-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.8-R0.1-SNAPSHOT")
     shadow("org.jetbrains.kotlin:kotlin-stdlib")
     implementation ("org.slf4j:slf4j-nop:2.0.13")
     implementation("com.zaxxer:HikariCP:5.1.0")

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PlayerClaimProtectionListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/PlayerClaimProtectionListener.kt
@@ -87,7 +87,6 @@ class PlayerClaimProtectionListener: Listener, KoinComponent {
         cancelIfDisallowed(event, player, event.entity.location, action)
     }
 
-    @Suppress("UnstableApiUsage")
     @EventHandler
     fun onEntityDeathEvent(event: EntityDeathEvent) {
         if (event.entity !is ArmorStand) return
@@ -301,11 +300,19 @@ class PlayerClaimProtectionListener: Listener, KoinComponent {
         val clickedEntity = event.rightClicked
         val heldItem = player.inventory.itemInMainHand
 
-        val isCancelled = when (clickedEntity) {
-            is Horse -> heldItem.type == Material.SADDLE
-            is Pig -> heldItem.type == Material.SADDLE
-            is ChestedHorse -> !clickedEntity.isCarryingChest && heldItem.type == Material.CHEST
-            is HappyGhast -> Tag.ITEMS_HARNESSES.isTagged(heldItem.type) || heldItem.type == Material.SHEARS
+        // Use a variable to store the HappyGhast class reference
+        // This is lazy-loaded and will be null on older versions
+        val happyGhastClass = try {
+            Class.forName("org.bukkit.entity.HappyGhast")
+        } catch (_: ClassNotFoundException) {
+            null
+        }
+
+        val isCancelled = when {
+            clickedEntity is Horse -> heldItem.type == Material.SADDLE
+            clickedEntity is Pig -> heldItem.type == Material.SADDLE
+            clickedEntity is ChestedHorse -> !clickedEntity.isCarryingChest && heldItem.type == Material.CHEST
+            happyGhastClass != null && happyGhastClass.isInstance(clickedEntity) -> Tag.ITEMS_HARNESSES.isTagged(heldItem.type) || heldItem.type == Material.SHEARS
             else -> false
         }
 


### PR DESCRIPTION
A major downside of restricting mob riding is that players can lose their horses, happy ghasts or other ridable mob in someone else's claim. While this allows players to steal ridable mobs, it's an acceptable compromise.