### PR TITLE
Implement claim name display on enter and exit

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,6 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <option name="SOFT_MARGINS" value="80" />
+    <option name="RIGHT_MARGIN" value="100" />
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [0.5.0]
+
+### Added
+- Action bar popup text on entering and exiting claim.
+
 ## [0.4.4]
 
 ### Added

--- a/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
@@ -180,6 +180,7 @@ class BellClaims : JavaPlugin() {
         server.pluginManager.registerEvents(ClaimDestructionListener(), this)
         server.pluginManager.registerEvents(CloseInventoryListener(), this)
         server.pluginManager.registerEvents(EditToolListener(), this)
+        server.pluginManager.registerEvents(ClaimEnterListener(), this)
         server.pluginManager.registerEvents(EditToolVisualisingListener(this), this)
         server.pluginManager.registerEvents(HarvestReplantListener(), this)
         server.pluginManager.registerEvents(MoveToolListener(), this)

--- a/src/main/kotlin/dev/mizarc/bellclaims/config/MainConfig.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/config/MainConfig.kt
@@ -9,6 +9,7 @@ data class MainConfig(
     var visualiserHideDelayPeriod: Double = 0.0,
     var visualiserRefreshPeriod: Double = 0.0,
     var rightClickHarvest: Boolean = true,
+    var showClaimEnterPopup: Boolean = true,
     var pluginLanguage: String = "EN",
     var customClaimToolModelId: Int = 732000,
     var customMoveToolModelId: Int = 732001

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/values/LocalizationKeys.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/values/LocalizationKeys.kt
@@ -15,6 +15,8 @@ object LocalizationKeys {
     // Claim
     const val FEEDBACK_CLAIM_DENIED = "feedback.claim.denied"
     const val FEEDBACK_CLAIM_OWNER = "feedback.claim.owner"
+    const val FEEDBACK_CLAIM_ENTER = "feedback.claim.enter"
+    const val FEEDBACK_CLAIM_LEAVE = "feedback.claim.leave"
 
     // Destruction
     const val FEEDBACK_DESTRUCTION_ATTACHED = "feedback.destruction.attached"

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/ConfigServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/ConfigServiceBukkit.kt
@@ -16,6 +16,7 @@ class ConfigServiceBukkit(private val config: FileConfiguration): ConfigService 
             visualiserHideDelayPeriod = config.getDouble("visualiser_hide_delay_period"),
             visualiserRefreshPeriod = config.getDouble("visualiser_refresh_period"),
             pluginLanguage = config.getString("plugin_language") ?: "",
+            showClaimEnterPopup = config.getBoolean("show_claim_enter_popup", true),
             customClaimToolModelId = config.getInt("custom_claim_tool_model_id"),
             customMoveToolModelId = config.getInt("custom_move_tool_model_id")
         )

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimEnterListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimEnterListener.kt
@@ -1,0 +1,108 @@
+package dev.mizarc.bellclaims.interaction.listeners
+
+import dev.mizarc.bellclaims.application.actions.claim.GetClaimAtPosition
+import dev.mizarc.bellclaims.application.results.claim.GetClaimAtPositionResult
+import dev.mizarc.bellclaims.application.utilities.LocalizationProvider
+import dev.mizarc.bellclaims.domain.entities.Claim
+import dev.mizarc.bellclaims.domain.values.LocalizationKeys
+import dev.mizarc.bellclaims.infrastructure.adapters.bukkit.toPosition2D
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.TextColor
+import org.bukkit.Location
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerChangedWorldEvent
+import org.bukkit.event.player.PlayerJoinEvent
+import org.bukkit.event.player.PlayerMoveEvent
+import org.bukkit.event.player.PlayerTeleportEvent
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import java.util.UUID
+import dev.mizarc.bellclaims.config.MainConfig
+
+/**
+ * Sends an action bar message when a player crosses into or out of a claim.
+ */
+class ClaimEnterListener: Listener, KoinComponent {
+    private val getClaimAtPosition: GetClaimAtPosition by inject()
+    private val localizationProvider: LocalizationProvider by inject()
+    private val config: MainConfig by inject()
+
+    // Throttle map to prevent excessive checks per player (ms)
+    private val lastCheckAt: MutableMap<UUID, Long> = mutableMapOf()
+    private val checkThrottleMs: Long = 250L // tuneable: 200-500ms
+
+    // Cache last known claim id per player to avoid spamming action bar
+    private val lastClaimForPlayer: MutableMap<UUID, UUID?> = mutableMapOf()
+
+    @EventHandler
+    fun onPlayerMove(event: PlayerMoveEvent) {
+        // Respect config toggle
+        if (!config.showClaimEnterPopup) return
+
+        val to = event.to
+        val from = event.from
+
+        // Ignore vertical-only movement and same chunk-level block (only X/Z/world changes matter)
+        if (from.world == to.world && from.blockX == to.blockX && from.blockZ == to.blockZ) return
+
+        val player = event.player
+        val playerId = player.uniqueId
+
+        // Throttle frequent checks for high-speed movement
+        val now = System.currentTimeMillis()
+        val last = lastCheckAt[playerId] ?: 0L
+        if (now - last < checkThrottleMs) return
+        lastCheckAt[playerId] = now
+
+        checkAndNotifyClaimChange(player, to)
+    }
+
+    @EventHandler
+    fun onPlayerTeleport(event: PlayerTeleportEvent) {
+        if (!config.showClaimEnterPopup) return
+        val to = event.to
+        checkAndNotifyClaimChange(event.player, to)
+    }
+
+    @EventHandler
+    fun onPlayerChangedWorld(event: PlayerChangedWorldEvent) {
+        if (!config.showClaimEnterPopup) return
+        checkAndNotifyClaimChange(event.player, event.player.location)
+    }
+
+    @EventHandler
+    fun onPlayerJoin(event: PlayerJoinEvent) {
+        if (!config.showClaimEnterPopup) return
+        // Initialize the player's last known claim so they don't get spammed on first movement
+        val player = event.player
+        val initialClaim = when (val result = getClaimAtPosition.execute(player.location.world.uid, player.location.toPosition2D())) {
+            is GetClaimAtPositionResult.Success -> result.claim
+            else -> null
+        }
+        lastClaimForPlayer[player.uniqueId] = initialClaim?.id
+    }
+
+    private fun checkAndNotifyClaimChange(player: Player, location: Location) {
+        val playerId = player.uniqueId
+        val newClaim: Claim? = when (val result = getClaimAtPosition.execute(location.world.uid, location.toPosition2D())) {
+            is GetClaimAtPositionResult.Success -> result.claim
+            else -> null
+        }
+
+        val newClaimId = newClaim?.id
+        val oldClaimId = lastClaimForPlayer[playerId]
+        if (oldClaimId == newClaimId) return
+        lastClaimForPlayer[playerId] = newClaimId
+
+        if (newClaim == null) {
+            val leaveMsg = localizationProvider.get(playerId, LocalizationKeys.FEEDBACK_CLAIM_LEAVE)
+            player.sendActionBar(Component.text(leaveMsg).color(TextColor.color(255, 200, 85)))
+        } else {
+            val name = newClaim.name.ifEmpty { newClaim.id.toString().take(7) }
+            val enterMsg = localizationProvider.get(playerId, LocalizationKeys.FEEDBACK_CLAIM_ENTER, name)
+            player.sendActionBar(Component.text(enterMsg).color(TextColor.color(85, 255, 165)))
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -24,6 +24,10 @@ visualiser_refresh_period: 1
 # add more <?>.properties files in the override folder to
 plugin_language: EN
 
+# Show an action bar message when players enter/leave claims
+# Set to false to disable the enter/leave action bar notifications
+show_claim_enter_popup: true
+
 # The id value for resource packs that change the model of the claim tool.
 custom_claim_tool_model_id: 732000
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -25,7 +25,6 @@ visualiser_refresh_period: 1
 plugin_language: EN
 
 # Show an action bar message when players enter/leave claims
-# Set to false to disable the enter/leave action bar notifications
 show_claim_enter_popup: true
 
 # The id value for resource packs that change the model of the claim tool.

--- a/src/main/resources/lang/defaults/en.properties
+++ b/src/main/resources/lang/defaults/en.properties
@@ -19,7 +19,7 @@ general.list_separator=,
 feedback.claim.denied=You can''t do that in {0}''s claim!
 feedback.claim.owner=This claim bell is owned by {0}
 feedback.claim.enter=Entering {0}
-feedback.claim.leave=You are now in the wilderness
+feedback.claim.leave=You're now in an unprotected area
 
 # Edit Tool
 feedback.edit_tool.in_claim=That selection would result in the claim bell being outside the claim area

--- a/src/main/resources/lang/defaults/en.properties
+++ b/src/main/resources/lang/defaults/en.properties
@@ -18,6 +18,8 @@ general.list_separator=,
 # Claim
 feedback.claim.denied=You can''t do that in {0}''s claim!
 feedback.claim.owner=This claim bell is owned by {0}
+feedback.claim.enter=Entering {0}
+feedback.claim.leave=You are now in the wilderness
 
 # Edit Tool
 feedback.edit_tool.in_claim=That selection would result in the claim bell being outside the claim area


### PR DESCRIPTION
A text display on the action bar is now displayed when the player enters or exits a claim. On entry, it displays the name of the claim. On exit, it displays "You're now in an unprotected area" to signify that the player has left the claim.

This feature is toggled by a config value, as well as an editable language file entry.