### PR TITLE
Implement auto claim visualisation refresh when moving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Added
 - Action bar popup text on entering and exiting claim.
-- New flag for villagers' ability to use doors
+- New flag for villagers' ability to use doors.
+- Auto claim visualisation refresh when moving between chunks.
 
 ## [0.4.4]
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
@@ -178,6 +178,7 @@ class BellClaims : JavaPlugin() {
         server.pluginManager.registerEvents(BlockLaunchListener(this), this)
         server.pluginManager.registerEvents(ClaimAnchorListener(), this)
         server.pluginManager.registerEvents(ClaimDestructionListener(), this)
+        server.pluginManager.registerEvents(ClaimToolAutoVisualisingListener(this), this)
         server.pluginManager.registerEvents(CloseInventoryListener(), this)
         server.pluginManager.registerEvents(EditToolListener(), this)
         server.pluginManager.registerEvents(ClaimEnterListener(), this)

--- a/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
@@ -178,7 +178,7 @@ class BellClaims : JavaPlugin() {
         server.pluginManager.registerEvents(BlockLaunchListener(this), this)
         server.pluginManager.registerEvents(ClaimAnchorListener(), this)
         server.pluginManager.registerEvents(ClaimDestructionListener(), this)
-        server.pluginManager.registerEvents(ClaimToolAutoVisualisingListener(this), this)
+        server.pluginManager.registerEvents(ClaimToolAutoVisualisingListener(), this)
         server.pluginManager.registerEvents(CloseInventoryListener(), this)
         server.pluginManager.registerEvents(EditToolListener(), this)
         server.pluginManager.registerEvents(ClaimEnterListener(), this)

--- a/src/main/kotlin/dev/mizarc/bellclaims/config/MainConfig.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/config/MainConfig.kt
@@ -8,6 +8,7 @@ data class MainConfig(
     var distanceBetweenClaims: Int = 0,
     var visualiserHideDelayPeriod: Double = 0.0,
     var visualiserRefreshPeriod: Double = 0.0,
+    var autoRefreshVisualisation: Boolean = true,
     var rightClickHarvest: Boolean = true,
     var showClaimEnterPopup: Boolean = true,
     var pluginLanguage: String = "EN",

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/ConfigServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/ConfigServiceBukkit.kt
@@ -15,6 +15,7 @@ class ConfigServiceBukkit(private val config: FileConfiguration): ConfigService 
             distanceBetweenClaims = config.getInt("distance_between_claims"),
             visualiserHideDelayPeriod = config.getDouble("visualiser_hide_delay_period"),
             visualiserRefreshPeriod = config.getDouble("visualiser_refresh_period"),
+            autoRefreshVisualisation = config.getBoolean("auto_refresh_visualisation", true),
             pluginLanguage = config.getString("plugin_language") ?: "",
             showClaimEnterPopup = config.getBoolean("show_claim_enter_popup", true),
             customClaimToolModelId = config.getInt("custom_claim_tool_model_id"),

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimToolAutoVisualisingListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimToolAutoVisualisingListener.kt
@@ -1,0 +1,64 @@
+package dev.mizarc.bellclaims.interaction.listeners
+
+import dev.mizarc.bellclaims.application.actions.player.tool.SyncToolVisualization
+import dev.mizarc.bellclaims.infrastructure.adapters.bukkit.toCustomItemData
+import dev.mizarc.bellclaims.infrastructure.adapters.bukkit.toPosition3D
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerMoveEvent
+import org.bukkit.plugin.java.JavaPlugin
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import java.util.UUID
+
+/**
+ * Automatically updates claim visualizations when a player crosses chunk borders while holding the
+ * claim tool.
+ */
+class ClaimToolAutoVisualisingListener(private val plugin: JavaPlugin): Listener, KoinComponent {
+    private val syncToolVisualization: SyncToolVisualization by inject()
+
+    // Track the last chunk position per player to detect chunk border crossings
+    private val lastChunkPosition: MutableMap<UUID, Pair<Int, Int>> = mutableMapOf()
+
+    @EventHandler
+    fun onPlayerMove(event: PlayerMoveEvent) {
+        val to = event.to
+        val from = event.from
+
+        // Early return if the player hasn't moved to another block
+        if (from.world == to.world && from.blockX == to.blockX && from.blockZ == to.blockZ) return
+
+        val player = event.player
+        val playerId = player.uniqueId
+        val toChunkX = to.chunk.x
+        val toChunkZ = to.chunk.z
+
+        // Check if the player crossed a chunk border
+        val lastChunk = lastChunkPosition[playerId]
+        if (lastChunk != null) {
+            val (lastChunkX, lastChunkZ) = lastChunk
+            if (lastChunkX == toChunkX && lastChunkZ == toChunkZ) return
+        }
+
+        // Update tracked chunk position
+        lastChunkPosition[playerId] = Pair(toChunkX, toChunkZ)
+
+        // Schedule visualization update on main thread
+        plugin.server.scheduler.runTask(plugin, Runnable {
+            handleAutoVisualisationUpdate(player)
+        })
+    }
+
+    /**
+     * Update the visualisation if the player is holding the claim tool
+     */
+    private fun handleAutoVisualisationUpdate(player: Player) {
+        val playerId = player.uniqueId
+        val position = player.location.toPosition3D()
+        val mainHand = player.inventory.itemInMainHand
+        val offHand = player.inventory.itemInOffHand
+        syncToolVisualization.execute(playerId, position, mainHand.toCustomItemData(), offHand.toCustomItemData())
+    }
+}

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimToolAutoVisualisingListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimToolAutoVisualisingListener.kt
@@ -1,13 +1,14 @@
 package dev.mizarc.bellclaims.interaction.listeners
 
 import dev.mizarc.bellclaims.application.actions.player.tool.SyncToolVisualization
+import dev.mizarc.bellclaims.application.services.ToolItemService
 import dev.mizarc.bellclaims.infrastructure.adapters.bukkit.toCustomItemData
 import dev.mizarc.bellclaims.infrastructure.adapters.bukkit.toPosition3D
-import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerChangedWorldEvent
 import org.bukkit.event.player.PlayerMoveEvent
-import org.bukkit.plugin.java.JavaPlugin
+import org.bukkit.event.player.PlayerQuitEvent
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.util.UUID
@@ -16,26 +17,33 @@ import java.util.UUID
  * Automatically updates claim visualizations when a player crosses chunk borders while holding the
  * claim tool.
  */
-class ClaimToolAutoVisualisingListener(private val plugin: JavaPlugin): Listener, KoinComponent {
+class ClaimToolAutoVisualisingListener: Listener, KoinComponent {
     private val syncToolVisualization: SyncToolVisualization by inject()
+    private val toolItemService: ToolItemService by inject()
 
     // Track the last chunk position per player to detect chunk border crossings
     private val lastChunkPosition: MutableMap<UUID, Pair<Int, Int>> = mutableMapOf()
 
     @EventHandler
     fun onPlayerMove(event: PlayerMoveEvent) {
+        // Early return if the player hasn't moved to another block
         val to = event.to
         val from = event.from
-
-        // Early return if the player hasn't moved to another block
         if (from.world == to.world && from.blockX == to.blockX && from.blockZ == to.blockZ) return
 
         val player = event.player
         val playerId = player.uniqueId
-        val toChunkX = to.chunk.x
-        val toChunkZ = to.chunk.z
+
+        // Early return if the player is not holding the claim tool
+        val mainHand = player.inventory.itemInMainHand
+        val offHand = player.inventory.itemInOffHand
+        val mainHandData = mainHand.toCustomItemData()
+        val offHandData = offHand.toCustomItemData()
+        if (!toolItemService.isClaimTool(mainHandData) && !toolItemService.isClaimTool(offHandData)) return
 
         // Check if the player crossed a chunk border
+        val toChunkX = to.chunk.x
+        val toChunkZ = to.chunk.z
         val lastChunk = lastChunkPosition[playerId]
         if (lastChunk != null) {
             val (lastChunkX, lastChunkZ) = lastChunk
@@ -45,20 +53,18 @@ class ClaimToolAutoVisualisingListener(private val plugin: JavaPlugin): Listener
         // Update tracked chunk position
         lastChunkPosition[playerId] = Pair(toChunkX, toChunkZ)
 
-        // Schedule visualization update on main thread
-        plugin.server.scheduler.runTask(plugin, Runnable {
-            handleAutoVisualisationUpdate(player)
-        })
+        // Update visualization directly
+        val position = player.location.toPosition3D()
+        syncToolVisualization.execute(playerId, position, mainHandData, offHandData)
     }
 
-    /**
-     * Update the visualisation if the player is holding the claim tool
-     */
-    private fun handleAutoVisualisationUpdate(player: Player) {
-        val playerId = player.uniqueId
-        val position = player.location.toPosition3D()
-        val mainHand = player.inventory.itemInMainHand
-        val offHand = player.inventory.itemInOffHand
-        syncToolVisualization.execute(playerId, position, mainHand.toCustomItemData(), offHand.toCustomItemData())
+    @EventHandler
+    fun onPlayerQuit(event: PlayerQuitEvent) {
+        lastChunkPosition.remove(event.player.uniqueId)
+    }
+
+    @EventHandler
+    fun onPlayerChangedWorld(event: PlayerChangedWorldEvent) {
+        lastChunkPosition.remove(event.player.uniqueId)
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimToolAutoVisualisingListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ClaimToolAutoVisualisingListener.kt
@@ -1,6 +1,7 @@
 package dev.mizarc.bellclaims.interaction.listeners
 
 import dev.mizarc.bellclaims.application.actions.player.tool.SyncToolVisualization
+import dev.mizarc.bellclaims.config.MainConfig
 import dev.mizarc.bellclaims.infrastructure.adapters.bukkit.toCustomItemData
 import dev.mizarc.bellclaims.infrastructure.adapters.bukkit.toPosition3D
 import org.bukkit.event.EventHandler
@@ -18,12 +19,15 @@ import java.util.UUID
  */
 class ClaimToolAutoVisualisingListener: Listener, KoinComponent {
     private val syncToolVisualization: SyncToolVisualization by inject()
+    private val config: MainConfig by inject()
 
     // Track the last chunk position per player to detect chunk border crossings
     private val lastChunkPosition: MutableMap<UUID, Pair<Int, Int>> = mutableMapOf()
 
     @EventHandler
     fun onPlayerMove(event: PlayerMoveEvent) {
+        if (!config.autoRefreshVisualisation) return
+
         // Early return if the player hasn't moved to another block
         val to = event.to
         val from = event.from

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -19,6 +19,9 @@ visualiser_hide_delay_period: 2
 # The minimum amount of time in seconds the visualiser is allowed to be refreshed to prevent spam.
 visualiser_refresh_period: 1
 
+# Toggle whether claims can auto refresh as the player moves around.
+auto_refresh_visualisation: true
+
 # The language of text elements.
 # EN - Original
 # add more <?>.properties files in the override folder to

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -19,7 +19,7 @@ visualiser_hide_delay_period: 2
 # The minimum amount of time in seconds the visualiser is allowed to be refreshed to prevent spam.
 visualiser_refresh_period: 1
 
-# Toggle whether claims can auto refresh as the player moves around.
+# Toggle whether claims can automatically refresh as the player moves around.
 auto_refresh_visualisation: true
 
 # The language of text elements.


### PR DESCRIPTION
In order for the visualisation state to be updated as the player moved around the world, they had to either re-equip or interact with the world using the claim tool to bring it up to the most up to date state. This became an issue when players were moving beyond their initial view distance without updating the claim visualisation state.

This change allows for an auto visualisation refresh when players move between chunks, meaning they no longer have to manually refresh the visualisation. Bear in mind this could be quite performance intensive on servers with extensive claim areas or many players refreshing at once. Will need to see how best to optimise the claim visualisation further and to perform profiling.