### PR TITLE
Fixed visualiser refresh on command inventory modification and world join/switching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,9 @@ fabric.properties
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
 
+# Github Copilot persisted session migrations, see: https://github.com/microsoft/copilot-intellij-feedback/issues/712#issuecomment-3322062215
+.idea/**/copilot.data.migration.*.xml
+
 ### Intellij Patch ###
 # Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ### Added
 - Action bar popup text on entering and exiting claim.
 - New flag for villagers' ability to use doors.
-- Auto claim visualisation refresh when moving between chunks.
+- Auto claim visualisation refreshes when moving between chunks, joining the server, and switching dimensions.
+
+### Fixed
+- Visualiser can now refresh when modifying the item in the player's hand via commands (e.g. using /clear, and given via /claim)
 
 ## [0.4.4]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Auto claim visualisation refreshes when moving between chunks, joining the server, and switching dimensions.
 
 ### Fixed
-- Visualiser can now refresh when modifying the item in the player's hand via commands (e.g. using /clear, and given via /claim)
+- Visualiser can now refresh when the claim tool state in hand is changed externally (e.g. wiping inventory using /clear, given via /claim)
 
 ## [0.4.4]
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/tool/SyncToolVisualization.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/tool/SyncToolVisualization.kt
@@ -5,6 +5,7 @@ import dev.mizarc.bellclaims.application.actions.player.visualisation.IsPlayerVi
 import dev.mizarc.bellclaims.application.actions.player.visualisation.ScheduleClearVisualisation
 import dev.mizarc.bellclaims.application.results.player.visualisation.IsPlayerVisualisingResult
 import dev.mizarc.bellclaims.application.services.ToolItemService
+import dev.mizarc.bellclaims.domain.values.Position2D
 import dev.mizarc.bellclaims.domain.values.Position3D
 import java.util.UUID
 
@@ -13,7 +14,7 @@ class SyncToolVisualization(private val toolItemService: ToolItemService,
                                    private val scheduleClearVisualisation: ScheduleClearVisualisation,
                                    private val isPlayerVisualising: IsPlayerVisualising) {
     // Cache last known (holdingClaimTool, position) per player to avoid redundant work
-    private val lastState: MutableMap<UUID, Pair<Boolean, Position3D>> = mutableMapOf()
+    private val lastState: MutableMap<UUID, Pair<Boolean, Position2D>> = mutableMapOf()
 
     fun execute(playerId: UUID, position: Position3D,
                 mainHandItemData: Map<String, String>?, offHandItemData: Map<String, String>?) {
@@ -23,7 +24,7 @@ class SyncToolVisualization(private val toolItemService: ToolItemService,
 
         // Skip if nothing relevant changed since the last execution for this player
         val last = lastState[playerId]
-        val current = Pair(holdingClaimTool, position)
+        val current = Pair(holdingClaimTool,  Position2D(position.x, position.z))
 
         // Check if the player is holding the same tool and in the same chunk as before
         val lastHolding = last?.first

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/tool/SyncToolVisualization.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/tool/SyncToolVisualization.kt
@@ -20,6 +20,7 @@ class SyncToolVisualization(private val toolItemService: ToolItemService,
         // Check if player is holding tool based on the item they're holding
         val holdingClaimTool = (toolItemService.isClaimTool(mainHandItemData)
                 || (toolItemService.isClaimTool(offHandItemData)))
+        println(holdingClaimTool)
 
         // Skip if nothing relevant changed since the last execution for this player
         val last = lastState[playerId]
@@ -31,9 +32,13 @@ class SyncToolVisualization(private val toolItemService: ToolItemService,
         if (holdingClaimTool) {
             displayVisualisation.execute(playerId, position)
         } else {
-            val result = isPlayerVisualising.execute(playerId)
-            if (result is IsPlayerVisualisingResult.Success && result.isVisualising) {
-                scheduleClearVisualisation.execute(playerId)
+            // Only attempt to clear visualisation if the previous state was holding the claim tool
+            val wasHoldingTool = last?.first == true
+            if (wasHoldingTool) {
+                val result = isPlayerVisualising.execute(playerId)
+                if (result is IsPlayerVisualisingResult.Success && result.isVisualising) {
+                    scheduleClearVisualisation.execute(playerId)
+                }
             }
         }
     }

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/tool/SyncToolVisualization.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/tool/SyncToolVisualization.kt
@@ -24,7 +24,7 @@ class SyncToolVisualization(private val toolItemService: ToolItemService,
 
         // Skip if nothing relevant changed since the last execution for this player
         val last = lastState[playerId]
-        val current = Pair(holdingClaimTool,  Position2D(position.x, position.z))
+        val current = Pair(holdingClaimTool, Position2D(position.x, position.z))
 
         // Check if the player is holding the same tool and in the same chunk as before
         val lastHolding = last?.first

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/tool/SyncToolVisualization.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/tool/SyncToolVisualization.kt
@@ -20,12 +20,16 @@ class SyncToolVisualization(private val toolItemService: ToolItemService,
         // Check if player is holding tool based on the item they're holding
         val holdingClaimTool = (toolItemService.isClaimTool(mainHandItemData)
                 || (toolItemService.isClaimTool(offHandItemData)))
-        println(holdingClaimTool)
 
         // Skip if nothing relevant changed since the last execution for this player
         val last = lastState[playerId]
         val current = Pair(holdingClaimTool, position)
-        if (last == current) return
+
+        // Check if the player is holding the same tool and in the same chunk as before
+        val lastHolding = last?.first
+        val lastChunk = last?.second?.let { Pair(it.x shr 4, it.z shr 4) }
+        val currentChunk = Pair(position.x shr 4, position.z shr 4)
+        if (lastHolding != null && lastHolding == holdingClaimTool && lastChunk == currentChunk) return
         lastState[playerId] = current
 
         // Visualise or unvisualise depending on if player is holding claim tool

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/tool/SyncToolVisualization.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/tool/SyncToolVisualization.kt
@@ -13,7 +13,7 @@ class SyncToolVisualization(private val toolItemService: ToolItemService,
                                    private val displayVisualisation: DisplayVisualisation,
                                    private val scheduleClearVisualisation: ScheduleClearVisualisation,
                                    private val isPlayerVisualising: IsPlayerVisualising) {
-    // Cache last known (holdingClaimTool, position) per player to avoid redundant work
+    // Cache last known (holdingClaimTool, position) per player to avoid redundant work.
     private val lastState: MutableMap<UUID, Pair<Boolean, Position2D>> = mutableMapOf()
 
     fun execute(playerId: UUID, position: Position3D,
@@ -22,11 +22,10 @@ class SyncToolVisualization(private val toolItemService: ToolItemService,
         val holdingClaimTool = (toolItemService.isClaimTool(mainHandItemData)
                 || (toolItemService.isClaimTool(offHandItemData)))
 
-        // Skip if nothing relevant changed since the last execution for this player
+        // Skip if the player is holding the same tool and are in the same chunk as before.
+        // If there's no previous state, proceed so that the current state can be cached.
         val last = lastState[playerId]
         val current = Pair(holdingClaimTool, Position2D(position.x, position.z))
-
-        // Check if the player is holding the same tool and in the same chunk as before
         val lastHolding = last?.first
         val lastChunk = last?.second?.let { Pair(it.x shr 4, it.z shr 4) }
         val currentChunk = Pair(position.x shr 4, position.z shr 4)

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/tool/SyncToolVisualization.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/tool/SyncToolVisualization.kt
@@ -12,11 +12,20 @@ class SyncToolVisualization(private val toolItemService: ToolItemService,
                                    private val displayVisualisation: DisplayVisualisation,
                                    private val scheduleClearVisualisation: ScheduleClearVisualisation,
                                    private val isPlayerVisualising: IsPlayerVisualising) {
+    // Cache last known (holdingClaimTool, position) per player to avoid redundant work
+    private val lastState: MutableMap<UUID, Pair<Boolean, Position3D>> = mutableMapOf()
+
     fun execute(playerId: UUID, position: Position3D,
                 mainHandItemData: Map<String, String>?, offHandItemData: Map<String, String>?) {
         // Check if player is holding tool based on the item they're holding
         val holdingClaimTool = (toolItemService.isClaimTool(mainHandItemData)
                 || (toolItemService.isClaimTool(offHandItemData)))
+
+        // Skip if nothing relevant changed since the last execution for this player
+        val last = lastState[playerId]
+        val current = Pair(holdingClaimTool, position)
+        if (last == current) return
+        lastState[playerId] = current
 
         // Visualise or unvisualise depending on if player is holding claim tool
         if (holdingClaimTool) {
@@ -27,5 +36,10 @@ class SyncToolVisualization(private val toolItemService: ToolItemService,
                 scheduleClearVisualisation.execute(playerId)
             }
         }
+    }
+
+    // Optional helper to clear cached state for a player (callable from listeners on quit/world-change)
+    fun clearCacheForPlayer(playerId: UUID) {
+        lastState.remove(playerId)
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/DisplayVisualisation.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/DisplayVisualisation.kt
@@ -60,8 +60,6 @@ class DisplayVisualisation(private val playerStateRepository: PlayerStateReposit
         }
 
         // Set visualisation in the player state
-        playerState.scheduledVisualiserHide?.cancel()
-        playerState.scheduledVisualiserHide = null
         playerState.isVisualisingClaims = true
         playerState.lastVisualisationTime = Instant.now()
         playerStateRepository.update(playerState)

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/DisplayVisualisation.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/DisplayVisualisation.kt
@@ -31,12 +31,20 @@ class DisplayVisualisation(private val playerStateRepository: PlayerStateReposit
             playerStateRepository.add(playerState)
         }
 
-        // Check if allowed to refresh visualisation based on last visualisation time
+        // If there is a scheduled hide task, cancel it immediately — the player is re-displaying.
+        playerState.scheduledVisualiserHide?.cancel()
+        playerState.scheduledVisualiserHide = null
+
+        // Check if allowed to refresh visualisation based on the last visualisation time
+        // If not reached cooldown time, refresh the last visualisation time to set the new cooldown
         val refreshPeriodInMillis = (config.visualiserRefreshPeriod * 1000).toLong()
         val lastVisualisation = playerState.lastVisualisationTime
         if (lastVisualisation != null
-                && lastVisualisation.plus(Duration.ofMillis(refreshPeriodInMillis)).isAfter(Instant.now()))
+                && lastVisualisation.plus(Duration.ofMillis(refreshPeriodInMillis)).isAfter(Instant.now())) {
+            playerState.lastVisualisationTime = Instant.now()
+            playerStateRepository.update(playerState)
             return mutableMapOf()
+        }
 
         // Clear the active visualisation
         clearVisualisation.execute(playerId)
@@ -51,8 +59,9 @@ class DisplayVisualisation(private val playerStateRepository: PlayerStateReposit
             playerState.visualisedClaims = borders
         }
 
-        // Set visualisation in player state
+        // Set visualisation in the player state
         playerState.scheduledVisualiserHide?.cancel()
+        playerState.scheduledVisualiserHide = null
         playerState.isVisualisingClaims = true
         playerState.lastVisualisationTime = Instant.now()
         playerStateRepository.update(playerState)
@@ -80,7 +89,7 @@ class DisplayVisualisation(private val playerStateRepository: PlayerStateReposit
                     it != playerState.selectedBlock }
                     .toSet()
             } else {
-                // Get all partitions linked to found claim
+                // Get all partitions linked to the found claim
                 val partitions = partitionRepository.getByClaim(claim.id)
                 val areas = partitions.map { it.area }.toMutableSet()
 
@@ -141,7 +150,7 @@ class DisplayVisualisation(private val playerStateRepository: PlayerStateReposit
     }
 
     private fun handleNonOwnedClaimDisplay(playerId: UUID, claim: Claim): Set<Position3D> {
-        // Get all partitions linked to found claim
+        // Get all partitions linked to the found claim
         val partitions = partitionRepository.getByClaim(claim.id)
         val areas = partitions.map { it.area }.toMutableSet()
         return visualisationService.displayComplete(playerId, areas, "RED_GLAZED_TERRACOTTA", "RED_CARPET", "BLACK_GLAZED_TERRACOTTA", "BLACK_CARPET")

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/ScheduleClearVisualisation.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/player/visualisation/ScheduleClearVisualisation.kt
@@ -26,13 +26,13 @@ class ScheduleClearVisualisation(private val playerStateRepository: PlayerStateR
 
         // Only schedule a new timer if the player currently has a visualization active
         if (playerState.isVisualisingClaims) {
-            playerState.isVisualisingClaims = false
             val delayTicks = (20L * config.visualiserHideDelayPeriod).toLong()
             val task = schedulerService.schedule(delayTicks) {
                 clearVisualisation.execute(playerId)
                 clearSelectionVisualisation.execute(playerId)
             }
             playerState.scheduledVisualiserHide = task
+            playerStateRepository.update(playerState)
             return ScheduleClearVisualisationResult.Success
         } else {
             return ScheduleClearVisualisationResult.PlayerNotVisualising

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/adapters/bukkit/BukkitItemStackAdapter.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/adapters/bukkit/BukkitItemStackAdapter.kt
@@ -12,7 +12,7 @@ import org.bukkit.persistence.PersistentDataType
  * - Returns null if the receiver is null, has no item meta, or no recognised keys are present.
  */
 fun ItemStack?.toCustomItemData(): Map<String, String>? {
-    // Returns null values if the item does not have any metadata
+    // Returns null if the item does not have any metadata
     if (this == null || !this.hasItemMeta()) return null
     val itemMeta = this.itemMeta ?: return null
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/adapters/bukkit/BukkitItemStackAdapter.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/adapters/bukkit/BukkitItemStackAdapter.kt
@@ -4,21 +4,27 @@ import dev.mizarc.bellclaims.infrastructure.namespaces.ItemKeys
 import org.bukkit.inventory.ItemStack
 import org.bukkit.persistence.PersistentDataType
 
+/**
+ * Read custom persistent data from an ItemStack and return it as an immutable map.
+ *
+ * Notes:
+ * - Must be called on the Bukkit main thread (reads Bukkit API state).
+ * - Returns null if the receiver is null, has no item meta, or no recognised keys are present.
+ */
 fun ItemStack?.toCustomItemData(): Map<String, String>? {
-    if (this == null || !this.hasItemMeta()) {
-        return null
-    }
+    // Returns null values if the item does not have any metadata
+    if (this == null || !this.hasItemMeta()) return null
     val itemMeta = this.itemMeta ?: return null
-    val persistentDataContainer = itemMeta.persistentDataContainer
 
-    val metadataMap = mutableMapOf<String, String>()
-    if (persistentDataContainer.has(ItemKeys.MOVE_TOOL_KEY, PersistentDataType.STRING)) {
-        val value = persistentDataContainer.get(ItemKeys.MOVE_TOOL_KEY, PersistentDataType.STRING) ?: return null
-        metadataMap[ItemKeys.MOVE_TOOL_KEY.key] = value
+    // Get metadata values from data container
+    val container = itemMeta.persistentDataContainer
+    val moveValue = container.get(ItemKeys.MOVE_TOOL_KEY, PersistentDataType.STRING)
+    val claimValue = container.get(ItemKeys.CLAIM_TOOL_KEY, PersistentDataType.BOOLEAN)
+
+    // Return map if metadata value exists
+    if (moveValue == null && claimValue == null) return null
+    return buildMap {
+        if (moveValue != null) put(ItemKeys.MOVE_TOOL_KEY.key, moveValue)
+        if (claimValue != null) put(ItemKeys.CLAIM_TOOL_KEY.key, claimValue.toString())
     }
-    if (persistentDataContainer.has(ItemKeys.CLAIM_TOOL_KEY, PersistentDataType.BOOLEAN)) {
-        val value = persistentDataContainer.get(ItemKeys.CLAIM_TOOL_KEY, PersistentDataType.BOOLEAN) ?: return null
-        metadataMap[ItemKeys.CLAIM_TOOL_KEY.key] = value.toString()
-    }
-    return metadataMap
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolVisualisingListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolVisualisingListener.kt
@@ -12,6 +12,7 @@ import org.bukkit.event.inventory.InventoryClickEvent
 import org.bukkit.event.player.PlayerDropItemEvent
 import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.event.player.PlayerItemHeldEvent
+import org.bukkit.event.player.PlayerCommandPreprocessEvent
 import org.bukkit.plugin.java.JavaPlugin
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -21,10 +22,29 @@ class EditToolVisualisingListener(private val plugin: JavaPlugin): Listener, Koi
     private val syncToolVisualization: SyncToolVisualization by inject()
 
     /**
+     * Triggers when the player executes certain commands that modify their inventory
+     * (e.g. /clear or /claim). We schedule a sync one tick later so the command
+     * has already updated the player's inventory and we can correctly detect
+     * whether the claim tool was added/removed from their hands.
+     */
+    @EventHandler
+    fun onPlayerCommand(event: PlayerCommandPreprocessEvent) {
+        event.player.sendMessage("testing")
+        val message = event.message.lowercase()
+        event.player.sendMessage(message)
+        if (!message.startsWith("/clear") && !message.startsWith("/claim")) return
+        val player = event.player
+        event.player.sendMessage("got here")
+        // Run one tick later so the command has taken effect
+        plugin.server.scheduler.runTaskLater(plugin, Runnable { handleAutoVisualisation(player) }, 1L)
+    }
+
+    /**
      * Triggers when the player swaps to the claim tool in their inventory.
      */
     @EventHandler
     fun onHoldClaimTool(event: PlayerItemHeldEvent) {
+        event.player.sendMessage("holding")
         plugin.server.scheduler.runTask(plugin, Runnable { handleAutoVisualisation(event.player) })
     }
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolVisualisingListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolVisualisingListener.kt
@@ -88,13 +88,13 @@ class EditToolVisualisingListener(private val plugin: JavaPlugin): Listener, Koi
     @EventHandler
     fun onPlayerQuit(event: PlayerQuitEvent) {
         syncToolVisualization.clearCacheForPlayer(event.player.uniqueId)
-        // Clean up initialising set in case player quit before the delayed task ran.
         initialisingPlayers.remove(event.player.uniqueId)
     }
 
     @EventHandler
     fun onPlayerChangedWorld(event: PlayerChangedWorldEvent) {
         syncToolVisualization.clearCacheForPlayer(event.player.uniqueId)
+        plugin.server.scheduler.runTaskLater(plugin, Runnable { handleAutoVisualisation(event.player) }, 20L)
     }
 
     /**
@@ -110,7 +110,6 @@ class EditToolVisualisingListener(private val plugin: JavaPlugin): Listener, Koi
         val offData = offHand.toCustomItemData()
 
         val position = player.location.toPosition3D()
-        println("syncing")
 
         syncToolVisualization.execute(playerId, position, mainData, offData)
     }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolVisualisingListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolVisualisingListener.kt
@@ -19,12 +19,13 @@ import org.bukkit.plugin.java.JavaPlugin
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 
 class EditToolVisualisingListener(private val plugin: JavaPlugin): Listener, KoinComponent {
     private val syncToolVisualization: SyncToolVisualization by inject()
 
     // Track players who've just loaded in so we can ignore spurious inventory events until they're fully in-game
-    private val initialisingPlayers: MutableSet<UUID> = mutableSetOf()
+    private val initialisingPlayers: MutableSet<UUID> = ConcurrentHashMap.newKeySet()
 
     @EventHandler
     fun onPlayerPreLogin(event: AsyncPlayerPreLoginEvent) {


### PR DESCRIPTION
This PR mainly focuses on the existing ticket item for the bug where the visualiser will remain when doing /clear with the item in hand, and doesn't appear when using /claim with the item appearing on the held item slot.

Secondary, there are additional changes to support auto visualisation on world change and server join. This is not controlled by the auto vis flag as it should be called rarely enough to not have a notable performance impact.