### PR TITLE
Fixed inability to change player permissions when player is offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,13 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - New flag for villagers' ability to use doors.
 - Auto claim visualisation refreshes when moving between chunks, joining the server, and switching dimensions.
 
+### Changed
+- Optimised the visualisation checks with a pre-cache to ensure visualisation checks aren't unnecessarily run.
+
 ### Fixed
 - Visualiser can now refresh when the claim tool state in hand is changed externally (e.g. wiping inventory using /clear, given via /claim)
 - Visualisers showing up in all worlds instead of only the one where the claim exists in.
+- Player permissions can now be modified when the player is offline.
 
 ## [0.4.4]
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/values/LocalizationKeys.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/values/LocalizationKeys.kt
@@ -72,6 +72,7 @@ object LocalizationKeys {
     const val SEND_TRANSFER_CONDITION_BLOCKS = "send_transfer_condition.blocks"
     const val SEND_TRANSFER_CONDITION_CLAIMS = "send_transfer_condition.claims"
     const val SEND_TRANSFER_CONDITION_EXIST = "send_transfer_condition.exist"
+    const val SEND_TRANSFER_CONDITION_OFFLINE = "send_transfer_condition.offline"
     const val SEND_TRANSFER_CONDITION_OWNER = "send_transfer_condition.owner"
 
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/exceptions/OfflinePlayerLookupException.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/exceptions/OfflinePlayerLookupException.kt
@@ -1,0 +1,8 @@
+package dev.mizarc.bellclaims.infrastructure.exceptions
+
+/**
+ * Thrown when a synchronous metadata lookup for an offline player is attempted.
+ * This signals that the caller should perform the lookup asynchronously instead.
+ */
+class OfflinePlayerLookupException(message: String? = null, cause: Throwable? = null) : RuntimeException(message, cause)
+

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/PlayerMetadataServiceVault.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/PlayerMetadataServiceVault.kt
@@ -1,5 +1,6 @@
 package dev.mizarc.bellclaims.infrastructure.services
 
+import dev.mizarc.bellclaims.infrastructure.exceptions.OfflinePlayerLookupException
 import dev.mizarc.bellclaims.application.services.PlayerMetadataService
 import dev.mizarc.bellclaims.config.MainConfig
 import kotlinx.coroutines.Dispatchers
@@ -12,11 +13,17 @@ class PlayerMetadataServiceVault(private val metadata: Chat,
                                  private val config: MainConfig): PlayerMetadataService {
     override fun getPlayerClaimLimit(playerId: UUID): Int {
         val offlinePlayer = Bukkit.getOfflinePlayer(playerId)
+        if (!offlinePlayer.isOnline) {
+            throw OfflinePlayerLookupException("Synchronous metadata lookup attempted for offline player: $playerId")
+        }
         return metadata.getPlayerInfoInteger(null, offlinePlayer, "bellclaims.claim_limit", config.claimLimit)
     }
 
     override fun getPlayerClaimBlockLimit(playerId: UUID): Int {
         val offlinePlayer = Bukkit.getOfflinePlayer(playerId)
+        if (!offlinePlayer.isOnline) {
+            throw OfflinePlayerLookupException("Synchronous metadata lookup attempted for offline player: $playerId")
+        }
         return metadata.getPlayerInfoInteger(null, offlinePlayer, "bellclaims.claim_block_limit", config.claimBlockLimit)
     }
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/management/ClaimPlayerPermissionsMenu.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/management/ClaimPlayerPermissionsMenu.kt
@@ -25,7 +25,6 @@ import dev.mizarc.bellclaims.utils.createHead
 import dev.mizarc.bellclaims.utils.getIcon
 import dev.mizarc.bellclaims.utils.lore
 import dev.mizarc.bellclaims.utils.name
-import org.bukkit.Bukkit
 import org.bukkit.Material
 import org.bukkit.OfflinePlayer
 import org.bukkit.entity.Player

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/management/ClaimPlayerPermissionsMenu.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/management/ClaimPlayerPermissionsMenu.kt
@@ -25,6 +25,7 @@ import dev.mizarc.bellclaims.utils.createHead
 import dev.mizarc.bellclaims.utils.getIcon
 import dev.mizarc.bellclaims.utils.lore
 import dev.mizarc.bellclaims.utils.name
+import org.bukkit.Bukkit
 import org.bukkit.Material
 import org.bukkit.OfflinePlayer
 import org.bukkit.entity.Player
@@ -73,26 +74,36 @@ class ClaimPlayerPermissionsMenu(private val menuNavigator: MenuNavigator, priva
         addSelector(playerId, controlsPane, createHead(targetPlayer).name(targetPlayer.name ?:
             localizationProvider.get(playerId, LocalizationKeys.GENERAL_NAME_ERROR)), deselectAction, selectAction)
 
-        val transferRequestResult = doesPlayerHaveTransferRequest.execute(claim.id, targetPlayer.uniqueId)
-
         val guiTransferRequestItem: GuiItem
-        when (transferRequestResult) {
-            is DoesPlayerHaveTransferRequestResult.ClaimNotFound -> {
-                val transferRequestItem = ItemStack(Material.MAGMA_CREAM)
-                    .name(LocalizationKeys.MENU_PLAYER_PERMISSIONS_ITEM_CANNOT_TRANSFER_NAME)
-                    .lore(LocalizationKeys.SEND_TRANSFER_CONDITION_EXIST)
-                guiTransferRequestItem = GuiItem(transferRequestItem)
+        if (targetPlayer.isOnline) {
+            val transferRequestResult = doesPlayerHaveTransferRequest.execute(claim.id, targetPlayer.uniqueId)
+
+
+            when (transferRequestResult) {
+                is DoesPlayerHaveTransferRequestResult.ClaimNotFound -> {
+                    val transferRequestItem = ItemStack(Material.MAGMA_CREAM)
+                        .name(LocalizationKeys.MENU_PLAYER_PERMISSIONS_ITEM_CANNOT_TRANSFER_NAME)
+                        .lore(LocalizationKeys.SEND_TRANSFER_CONDITION_EXIST)
+                    guiTransferRequestItem = GuiItem(transferRequestItem)
+                }
+                is DoesPlayerHaveTransferRequestResult.StorageError -> {
+                    val transferRequestItem = ItemStack(Material.MAGMA_CREAM)
+                        .name(localizationProvider.get(playerId, LocalizationKeys.MENU_COMMON_ITEM_ERROR_NAME))
+                        .lore(localizationProvider.get(playerId, LocalizationKeys.MENU_COMMON_ITEM_ERROR_LORE))
+                    guiTransferRequestItem = GuiItem(transferRequestItem)
+                }
+                is DoesPlayerHaveTransferRequestResult.Success -> {
+                    guiTransferRequestItem = createTransferButton(playerId, transferRequestResult.hasRequest)
+                }
             }
-            is DoesPlayerHaveTransferRequestResult.StorageError -> {
-                val transferRequestItem = ItemStack(Material.MAGMA_CREAM)
-                    .name(localizationProvider.get(playerId, LocalizationKeys.MENU_COMMON_ITEM_ERROR_NAME))
-                    .lore(localizationProvider.get(playerId, LocalizationKeys.MENU_COMMON_ITEM_ERROR_LORE))
-                guiTransferRequestItem = GuiItem(transferRequestItem)
-            }
-            is DoesPlayerHaveTransferRequestResult.Success -> {
-                guiTransferRequestItem = createTransferButton(playerId, transferRequestResult.hasRequest)
-            }
+        } else {
+            val transferRequestItem = ItemStack(Material.MAGMA_CREAM)
+                .name(localizationProvider.get(playerId, LocalizationKeys.MENU_PLAYER_PERMISSIONS_ITEM_CANNOT_TRANSFER_NAME))
+                .lore(localizationProvider.get(playerId, LocalizationKeys.SEND_TRANSFER_CONDITION_OFFLINE))
+            guiTransferRequestItem = GuiItem(transferRequestItem)
         }
+
+
         controlsPane.addItem(guiTransferRequestItem, 8, 0)
 
         // Add vertical divider

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/management/ClaimPlayerPermissionsMenu.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/management/ClaimPlayerPermissionsMenu.kt
@@ -78,7 +78,6 @@ class ClaimPlayerPermissionsMenu(private val menuNavigator: MenuNavigator, priva
         if (targetPlayer.isOnline) {
             val transferRequestResult = doesPlayerHaveTransferRequest.execute(claim.id, targetPlayer.uniqueId)
 
-
             when (transferRequestResult) {
                 is DoesPlayerHaveTransferRequestResult.ClaimNotFound -> {
                     val transferRequestItem = ItemStack(Material.MAGMA_CREAM)
@@ -102,7 +101,6 @@ class ClaimPlayerPermissionsMenu(private val menuNavigator: MenuNavigator, priva
                 .lore(localizationProvider.get(playerId, LocalizationKeys.SEND_TRANSFER_CONDITION_OFFLINE))
             guiTransferRequestItem = GuiItem(transferRequestItem)
         }
-
 
         controlsPane.addItem(guiTransferRequestItem, 8, 0)
 

--- a/src/main/resources/lang/defaults/en.properties
+++ b/src/main/resources/lang/defaults/en.properties
@@ -75,6 +75,7 @@ creation_condition.world_border=Too close to the world border to establish a cla
 send_transfer_condition.blocks=Player has insufficient claim blocks.
 send_transfer_condition.claims=Player has run out of claims.
 send_transfer_condition.exist=This claim no longer exists, you probably shouldn''t still be here.
+send_transfer_condition.offline=Player is currently offline.
 send_transfer_condition.owner=You own this claim, you probably shouldn''t still be here.
 
 


### PR DESCRIPTION
Due to Vault connection (likely via LuckPerms) requiring requests to be done async for offline players, the player permission menu was inaccessible. A simple solution is to simply disallow claim transfer requests to offline players.