### PR TITLE
Allow server administrators to blacklist the use of certain flags and permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Action bar popup text on entering and exiting claim.
 - New flag for villagers' ability to use doors.
 - Auto claim visualisation refreshes when moving between chunks, joining the server, and switching dimensions.
+- New config options to blacklist certain permissions and flags. This allows the action that would be blocked by permission/flag to always be allowed.
 
 ### Changed
 - Optimised the visualisation checks with a pre-cache to ensure visualisation checks aren't unnecessarily run.
@@ -18,6 +19,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Visualiser can now refresh when the claim tool state in hand is changed externally (e.g. wiping inventory using /clear, given via /claim)
 - Visualisers showing up in all worlds instead of only the one where the claim exists in.
 - Player permissions can now be modified when the player is offline.
+- The button to Select all on player permissions works as intended.
 
 ## [0.4.4]
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ fun getProperty(name: String): String {
 // =========================================================
 
 group = "dev.mizarc"
-version = "0.4.4"
+version = "0.5.0"
 
 repositories {
     mavenLocal()

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/IsPlayerActionAllowed.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/IsPlayerActionAllowed.kt
@@ -16,8 +16,7 @@ class IsPlayerActionAllowed(private val playerAccessRepository: PlayerAccessRepo
                             private val claimPermissionRepository: ClaimPermissionRepository,
                             private val getClaimAtPosition: GetClaimAtPosition,
                             private val playerStateRepository: PlayerStateRepository,
-                            private val mainConfig: MainConfig
-) {
+                            private val mainConfig: MainConfig) {
     fun execute(playerId: UUID, worldId: UUID, position: Position2D,
                 playerActionType: PlayerActionType): IsPlayerActionAllowedResult {
         // Get the claim at the current position

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/permission/GrantAllClaimWidePermissions.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/permission/GrantAllClaimWidePermissions.kt
@@ -4,11 +4,14 @@ import dev.mizarc.bellclaims.application.errors.DatabaseOperationException
 import dev.mizarc.bellclaims.application.persistence.ClaimPermissionRepository
 import dev.mizarc.bellclaims.application.persistence.ClaimRepository
 import dev.mizarc.bellclaims.application.results.claim.permission.GrantAllClaimWidePermissionsResult
+import dev.mizarc.bellclaims.config.MainConfig
 import dev.mizarc.bellclaims.domain.values.ClaimPermission
 import java.util.UUID
+import kotlin.text.equals
 
 class GrantAllClaimWidePermissions(private val claimPermissionRepository: ClaimPermissionRepository,
-                                   private val claimRepository: ClaimRepository) {
+                                   private val claimRepository: ClaimRepository,
+                                   private val config: MainConfig) {
     /**
      * Adds all available flags to the claim with the given [claimId].
      *
@@ -16,13 +19,14 @@ class GrantAllClaimWidePermissions(private val claimPermissionRepository: ClaimP
      * @return An [GrantAllClaimWidePermissionsResult] indicating the outcome of the flag addition operation.
      */
     fun execute(claimId: UUID): GrantAllClaimWidePermissionsResult {
-        // Check if claim exists
+        // Check if the claim exists
         claimRepository.getById(claimId) ?: return GrantAllClaimWidePermissionsResult.ClaimWideNotFound
 
         // Add all flags to the claim
         var anyPermissionEnabled = false
         try {
             val allPermissions = ClaimPermission.entries
+                .filter { permission -> !config.blacklistedPermissions.any { it.equals(permission.name, ignoreCase = true) } }
             for (permission in allPermissions) {
                 if (claimPermissionRepository.add(claimId, permission)) anyPermissionEnabled = true
             }

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/permission/GrantAllPlayerClaimPermissions.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/permission/GrantAllPlayerClaimPermissions.kt
@@ -24,7 +24,7 @@ class GrantAllPlayerClaimPermissions(private val claimRepository: ClaimRepositor
         try {
             val allPermissions = ClaimPermission.entries
             for (permission in allPermissions) {
-                if (playerAccessRepository.remove(claimId, playerId, permission)) anyPermissionEnabled = true
+                if (playerAccessRepository.add(claimId, playerId, permission)) anyPermissionEnabled = true
             }
 
             // Return success if at least one permission was granted

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/permission/GrantAllPlayerClaimPermissions.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/permission/GrantAllPlayerClaimPermissions.kt
@@ -4,11 +4,14 @@ import dev.mizarc.bellclaims.application.errors.DatabaseOperationException
 import dev.mizarc.bellclaims.application.persistence.ClaimRepository
 import dev.mizarc.bellclaims.application.persistence.PlayerAccessRepository
 import dev.mizarc.bellclaims.application.results.claim.permission.GrantAllPlayerClaimPermissionsResult
+import dev.mizarc.bellclaims.config.MainConfig
 import dev.mizarc.bellclaims.domain.values.ClaimPermission
 import java.util.UUID
+import kotlin.text.equals
 
 class GrantAllPlayerClaimPermissions(private val claimRepository: ClaimRepository,
-                                      private val playerAccessRepository: PlayerAccessRepository) {
+                                     private val playerAccessRepository: PlayerAccessRepository,
+                                     private val config: MainConfig) {
     /**
      * Adds all available permissions to the claim with the given [claimId].
      *
@@ -23,6 +26,7 @@ class GrantAllPlayerClaimPermissions(private val claimRepository: ClaimRepositor
         var anyPermissionEnabled = false
         try {
             val allPermissions = ClaimPermission.entries
+                .filter { permission -> !config.blacklistedPermissions.any { it.equals(permission.name, ignoreCase = true) } }
             for (permission in allPermissions) {
                 if (playerAccessRepository.add(claimId, playerId, permission)) anyPermissionEnabled = true
             }

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/results/claim/flags/EnableClaimFlagResult.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/results/claim/flags/EnableClaimFlagResult.kt
@@ -5,4 +5,5 @@ sealed class EnableClaimFlagResult {
     object ClaimNotFound : EnableClaimFlagResult()
     object AlreadyExists : EnableClaimFlagResult()
     object StorageError: EnableClaimFlagResult()
+    object Blacklisted: EnableClaimFlagResult()
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/config/MainConfig.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/config/MainConfig.kt
@@ -13,5 +13,7 @@ data class MainConfig(
     var showClaimEnterPopup: Boolean = true,
     var pluginLanguage: String = "EN",
     var customClaimToolModelId: Int = 732000,
-    var customMoveToolModelId: Int = 732001
+    var customMoveToolModelId: Int = 732001,
+    var blacklistedFlags: Set<String> = emptySet(),
+    var blacklistedPermissions: Set<String> = emptySet()
 )

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/values/LocalizationKeys.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/values/LocalizationKeys.kt
@@ -283,6 +283,7 @@ object LocalizationKeys {
     // Add Flag
     const val COMMAND_CLAIM_ADD_FLAG_SUCCESS = "command.claim.add_flag.success"
     const val COMMAND_CLAIM_ADD_FLAG_ALREADY_EXISTS = "command.claim.add_flag.already_exists"
+    const val COMMAND_CLAIM_ADD_FLAG_BLACKLISTED = "command.claim.add_flag.blacklisted"
 
     // Claim
     const val COMMAND_CLAIM_SUCCESS = "command.claim.success"

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/ConfigServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/ConfigServiceBukkit.kt
@@ -3,10 +3,19 @@ package dev.mizarc.bellclaims.infrastructure.services
 import dev.mizarc.bellclaims.application.services.ConfigService
 import dev.mizarc.bellclaims.config.MainConfig
 import org.bukkit.configuration.file.FileConfiguration
-import org.eclipse.sisu.launch.Main
 
 class ConfigServiceBukkit(private val config: FileConfiguration): ConfigService {
     override fun loadConfig(): MainConfig {
+        val flags = config.getStringList("blacklisted_flags")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .toSet()
+
+        val permissions = config.getStringList("blacklisted_permissions")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .toSet()
+
         return MainConfig(
             claimLimit = config.getInt("claim_limit"),
             claimBlockLimit = config.getInt("claim_block_limit"),
@@ -19,7 +28,9 @@ class ConfigServiceBukkit(private val config: FileConfiguration): ConfigService 
             pluginLanguage = config.getString("plugin_language") ?: "",
             showClaimEnterPopup = config.getBoolean("show_claim_enter_popup", true),
             customClaimToolModelId = config.getInt("custom_claim_tool_model_id"),
-            customMoveToolModelId = config.getInt("custom_move_tool_model_id")
+            customMoveToolModelId = config.getInt("custom_move_tool_model_id"),
+            blacklistedFlags = flags,
+            blacklistedPermissions = permissions
         )
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/commands/AddFlagCommand.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/commands/AddFlagCommand.kt
@@ -49,6 +49,10 @@ class AddFlagCommand : ClaimCommand(), KoinComponent {
                 LocalizationKeys.GENERAL_ERROR,
                 emptyArray<String>()
             )
+            EnableClaimFlagResult.Blacklisted -> Pair(
+                LocalizationKeys.COMMAND_CLAIM_ADD_FLAG_BLACKLISTED,
+                emptyArray<String>()
+            )
         }
 
         // Output to player chat

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/management/ClaimFlagMenu.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/management/ClaimFlagMenu.kt
@@ -141,7 +141,7 @@ class ClaimFlagMenu(private val menuNavigator: MenuNavigator, private val player
         for (flag in enabledBlacklistedFlags) {
             val permissionItem = flag.getIcon(localizationProvider, playerId)
             permissionItem.lore("§c[BLACKLISTED]", 0)
-            permissionItem.lore("§7This permission is currently blacklisted by the server. ", 1)
+            permissionItem.lore("§7This flag is currently blacklisted by the server.", 1)
             permissionItem.lore("§7It currently has no effect and can be safely disabled.", 2)
             permissionItem.lore("", 3)
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/management/ClaimPlayerPermissionsMenu.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/management/ClaimPlayerPermissionsMenu.kt
@@ -15,8 +15,10 @@ import dev.mizarc.bellclaims.application.actions.claim.transfer.WithdrawPlayerTr
 import dev.mizarc.bellclaims.application.results.claim.transfer.CanPlayerReceiveTransferRequestResult
 import dev.mizarc.bellclaims.application.results.claim.transfer.DoesPlayerHaveTransferRequestResult
 import dev.mizarc.bellclaims.application.utilities.LocalizationProvider
+import dev.mizarc.bellclaims.config.MainConfig
 import dev.mizarc.bellclaims.domain.entities.Claim
 import dev.mizarc.bellclaims.domain.values.ClaimPermission
+import dev.mizarc.bellclaims.domain.values.Flag
 import dev.mizarc.bellclaims.domain.values.LocalizationKeys
 import dev.mizarc.bellclaims.interaction.menus.Menu
 import dev.mizarc.bellclaims.interaction.menus.MenuNavigator
@@ -33,6 +35,7 @@ import org.bukkit.inventory.ItemStack
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.util.UUID
+import kotlin.text.equals
 
 class ClaimPlayerPermissionsMenu(private val menuNavigator: MenuNavigator, private val player: Player,
                                  private val claim: Claim, private val targetPlayer: OfflinePlayer
@@ -47,6 +50,7 @@ class ClaimPlayerPermissionsMenu(private val menuNavigator: MenuNavigator, priva
     private val doesPlayerHaveTransferRequest: DoesPlayerHaveTransferRequest by inject()
     private val offerPlayerTransferRequest: OfferPlayerTransferRequest by inject()
     private val withdrawPlayerTransferRequest: WithdrawPlayerTransferRequest by inject()
+    private val mainConfig: MainConfig by inject()
 
     override fun open() {
         // Create player permissions menu
@@ -112,10 +116,12 @@ class ClaimPlayerPermissionsMenu(private val menuNavigator: MenuNavigator, priva
             verticalDividerPane.addItem(guiDividerItem, 0, slot)
         }
 
-        val enabledPermissions = getPlayerClaimPermissions.execute(claim.id, targetPlayer.uniqueId)
-        val disabledPermissions = ClaimPermission.entries.toTypedArray().subtract(enabledPermissions)
+        val allEnabled = getPlayerClaimPermissions.execute(claim.id, targetPlayer.uniqueId)
+        val enabledPermissions = allEnabled.filter { permission -> !mainConfig.blacklistedPermissions.any { it.equals(permission.name, ignoreCase = true) } }
+        val enabledBlacklistedPermissions = allEnabled.filter { permission -> mainConfig.blacklistedPermissions.any { it.equals(permission.name, ignoreCase = true) } }
+        val disabledPermissions = ClaimPermission.entries.filter { permission -> !allEnabled.contains(permission) && !mainConfig.blacklistedPermissions.any { it.equals(permission.name, ignoreCase = true) } }
 
-        // Add list of disabled permissions
+        // Add a list of disabled permissions
         val disabledPermissionsPane = StaticPane(0, 2, 4, 4)
         gui.addPane(disabledPermissionsPane)
         var xSlot = 0
@@ -144,6 +150,28 @@ class ClaimPlayerPermissionsMenu(private val menuNavigator: MenuNavigator, priva
         ySlot = 0
         for (permission in enabledPermissions) {
             val permissionItem = permission.getIcon(localizationProvider, playerId)
+
+            val guiPermissionItem = GuiItem(permissionItem) {
+                revokePlayerClaimPermission.execute(claim.id, targetPlayer.uniqueId, permission)
+                open()
+            }
+
+            enabledPermissionsPane.addItem(guiPermissionItem , xSlot, ySlot)
+
+            // Increment slot
+            xSlot += 1
+            if (xSlot > 3) {
+                xSlot = 0
+                ySlot += 1
+            }
+        }
+
+        for (permission in enabledBlacklistedPermissions) {
+            val permissionItem = permission.getIcon(localizationProvider, playerId)
+            permissionItem.lore("§c[BLACKLISTED]", 0)
+            permissionItem.lore("§7This permission is currently blacklisted by the server.", 1)
+            permissionItem.lore("§7It currently has no effect and can be safely disabled.", 2)
+            permissionItem.lore("", 3)
 
             val guiPermissionItem = GuiItem(permissionItem) {
                 revokePlayerClaimPermission.execute(claim.id, targetPlayer.uniqueId, permission)

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/management/ClaimPlayerPermissionsMenu.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/management/ClaimPlayerPermissionsMenu.kt
@@ -18,7 +18,6 @@ import dev.mizarc.bellclaims.application.utilities.LocalizationProvider
 import dev.mizarc.bellclaims.config.MainConfig
 import dev.mizarc.bellclaims.domain.entities.Claim
 import dev.mizarc.bellclaims.domain.values.ClaimPermission
-import dev.mizarc.bellclaims.domain.values.Flag
 import dev.mizarc.bellclaims.domain.values.LocalizationKeys
 import dev.mizarc.bellclaims.interaction.menus.Menu
 import dev.mizarc.bellclaims.interaction.menus.MenuNavigator

--- a/src/main/kotlin/dev/mizarc/bellclaims/utils/ItemStackExtensions.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/utils/ItemStackExtensions.kt
@@ -36,6 +36,18 @@ fun ItemStack.lore(text: String): ItemStack {
     return this
 }
 
+fun ItemStack.lore(text: String, position: Int): ItemStack {
+    val meta = itemMeta
+    var lore: MutableList<String>? = meta.lore
+    if (lore == null) {
+        lore = ArrayList()
+    }
+    lore.add(position, text)
+    meta.lore = lore.c()
+    itemMeta = meta
+    return this
+}
+
 fun ItemStack.lore(vararg text: String): ItemStack {
     Arrays.stream(text).forEach { this.lore(it) }
     return this

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -35,3 +35,38 @@ custom_claim_tool_model_id: 732000
 
 # The id value for resource packs that change the model of the move tool.
 custom_move_tool_model_id: 732001
+
+# Blacklisted flags that players aren't allowed to set on their claims.
+# Uncomment flags you want to blacklist.
+blacklisted_flags:
+#  - EXPLOSION
+#  - FIRE
+#  - MOB
+#  - PISTON
+#  - FLUID
+#  - TREE
+#  - SCULK
+#  - DISPENSER
+#  - SPONGE
+#  - LIGHTNING
+#  - FALLING_BLOCK
+#  - PASSIVE_ENTITY_VEHICLE
+#  - VILLAGER_DOOR
+
+# Blacklisted permissions that players aren't allowed to set on their claims.
+# Uncomment permissions you want to blacklist.
+blacklisted_permissions:
+#  - BUILD
+#  - HARVEST
+#  - CONTAINER
+#  - DISPLAY
+#  - VEHICLE
+#  - SIGN
+#  - REDSTONE
+#  - DOOR
+#  - TRADE
+#  - HUSBANDRY
+#  - DETONATE
+#  - EVENT
+#  - SLEEP
+#  - VIEW

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: BellClaims
-version: 0.4.4
+version: 0.5.0
 api-version: '1.21'
 main: dev.mizarc.bellclaims.BellClaims
 softdepend: [Vault]


### PR DESCRIPTION
Blacklisting a flag or permission disallows players from being able to use these in their claims. Instead, the action that it would block if it were disabled is now always allowed.

If the flag/permission is already being used by the claim when the blacklist is enacted, it will remain in the menu's enabled list but have no effect. Removing it from there will permanently remove it from the menu's visibility.