### PR TITLE
Add exclusions for end portal, exit portal, and gateway spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - New flag for villagers' ability to use doors.
 - Auto claim visualisation refreshes when moving between chunks, joining the server, and switching dimensions.
 - New config options to blacklist certain permissions and flags. This allows the action that would be blocked by permission/flag to always be allowed.
+- Claim bells are now blocked from being created or moved into protected zones such as end portals and gateways.
 
 ### Changed
 - Optimised the visualisation checks with a pre-cache to ensure visualisation checks aren't unnecessarily run.

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/CreateClaim.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/CreateClaim.kt
@@ -67,6 +67,11 @@ class CreateClaim(private val claimRepository: ClaimRepository, private val part
             return CreateClaimResult.InvalidPosition
         }
 
+        // Disallow if too close to an end portal frame
+        if (worldManipulationService.isNearEndPortalFrame(worldId, position3D)) {
+            return CreateClaimResult.InvalidPosition
+        }
+
         // Creates new claim and partition
         val newClaim = Claim(worldId, playerId, position3D, name)
         val partition = Partition(newClaim.id, area)

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/CreateClaim.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/CreateClaim.kt
@@ -52,6 +52,11 @@ class CreateClaim(private val claimRepository: ClaimRepository, private val part
             return CreateClaimResult.TooCloseToWorldBorder
         }
 
+        // Disallow claims on the end platform
+        if (worldManipulationService.isOnEndPlatform(worldId, position3D)) {
+            return CreateClaimResult.InvalidPosition
+        }
+
         // Creates new claim and partition
         val newClaim = Claim(worldId, playerId, position3D, name)
         val partition = Partition(newClaim.id, area)

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/CreateClaim.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/actions/claim/CreateClaim.kt
@@ -57,6 +57,16 @@ class CreateClaim(private val claimRepository: ClaimRepository, private val part
             return CreateClaimResult.InvalidPosition
         }
 
+        // Disallow if inside the exit portal space
+        if (worldManipulationService.isInReturnEndPortal(worldId, position3D)) {
+            return CreateClaimResult.InvalidPosition
+        }
+
+        // Disallow if in the gateway orbit radius
+        if (worldManipulationService.isNearGatewayOrbit(worldId, position3D)) {
+            return CreateClaimResult.InvalidPosition
+        }
+
         // Creates new claim and partition
         val newClaim = Claim(worldId, playerId, position3D, name)
         val partition = Partition(newClaim.id, area)

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/results/claim/CreateClaimResult.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/results/claim/CreateClaimResult.kt
@@ -7,5 +7,6 @@ sealed class CreateClaimResult {
     object NameCannotBeBlank: CreateClaimResult()
     object LimitExceeded: CreateClaimResult()
     object NameAlreadyExists: CreateClaimResult()
+    object InvalidPosition: CreateClaimResult()
     object TooCloseToWorldBorder: CreateClaimResult()
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/results/claim/anchor/MoveClaimAnchorResult.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/results/claim/anchor/MoveClaimAnchorResult.kt
@@ -3,6 +3,7 @@ package dev.mizarc.bellclaims.application.results.claim.anchor
 sealed class MoveClaimAnchorResult {
     object Success: MoveClaimAnchorResult()
     object NoPermission: MoveClaimAnchorResult()
+    object OutsiderBorder: MoveClaimAnchorResult()
     object InvalidPosition: MoveClaimAnchorResult()
     object StorageError: MoveClaimAnchorResult()
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/services/WorldManipulationService.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/services/WorldManipulationService.kt
@@ -7,4 +7,5 @@ import java.util.UUID
 interface WorldManipulationService {
     fun breakWithoutItemDrop(worldId: UUID, position: Position3D): Boolean
     fun isInsideWorldBorder(worldId: UUID, area: Area): Boolean
+    fun isOnEndPlatform(worldId: UUID, position3D: Position3D): Boolean
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/services/WorldManipulationService.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/services/WorldManipulationService.kt
@@ -10,4 +10,5 @@ interface WorldManipulationService {
     fun isOnEndPlatform(worldId: UUID, position3D: Position3D): Boolean
     fun isInReturnEndPortal(worldId: UUID, position3D: Position3D): Boolean
     fun isNearGatewayOrbit(worldId: UUID, position3D: Position3D): Boolean
+    fun isNearEndPortalFrame(worldId: UUID, position3D: Position3D): Boolean
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/application/services/WorldManipulationService.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/application/services/WorldManipulationService.kt
@@ -8,4 +8,6 @@ interface WorldManipulationService {
     fun breakWithoutItemDrop(worldId: UUID, position: Position3D): Boolean
     fun isInsideWorldBorder(worldId: UUID, area: Area): Boolean
     fun isOnEndPlatform(worldId: UUID, position3D: Position3D): Boolean
+    fun isInReturnEndPortal(worldId: UUID, position3D: Position3D): Boolean
+    fun isNearGatewayOrbit(worldId: UUID, position3D: Position3D): Boolean
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/values/LocalizationKeys.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/values/LocalizationKeys.kt
@@ -67,6 +67,7 @@ object LocalizationKeys {
     const val CREATION_CONDITION_OVERLAP = "creation_condition.overlap"
     const val CREATION_CONDITION_UNNAMED = "creation_condition.unnamed"
     const val CREATION_CONDITION_WORLD_BORDER = "creation_condition.world_border"
+    const val CREATION_CONDITION_INVALID_POSITION = "creation_condition.invalid_position"
 
     // Transfer Conditions
     const val SEND_TRANSFER_CONDITION_BLOCKS = "send_transfer_condition.blocks"

--- a/src/main/kotlin/dev/mizarc/bellclaims/domain/values/LocalizationKeys.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/domain/values/LocalizationKeys.kt
@@ -45,6 +45,7 @@ object LocalizationKeys {
     // Move Tool
     const val FEEDBACK_MOVE_TOOL_SUCCESS = "feedback.move_tool.success"
     const val FEEDBACK_MOVE_TOOL_OUTSIDE_BORDER = "feedback.move_tool.outside_border"
+    const val FEEDBACK_MOVE_TOOL_INVALID_POSITION = "feedback.move_tool.invalid_position"
     const val FEEDBACK_MOVE_TOOL_NO_PERMISSION = "feedback.move_tool.no_permission"
 
     // Transfer

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/WorldManipulationServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/WorldManipulationServiceBukkit.kt
@@ -104,4 +104,28 @@ class WorldManipulationServiceBukkit : WorldManipulationService {
 
         return isInRing && isInHeightBuffer
     }
+
+    override fun isNearEndPortalFrame(worldId: UUID, position3D: Position3D): Boolean {
+        val world = Bukkit.getWorld(worldId) ?: return false
+
+        // Optimization: Strongholds only exist in the Overworld (standard)
+        // Though some custom servers have them elsewhere, checking everywhere is safer.
+
+        val radius = 2
+        for (x in -radius..radius) {
+            for (y in -radius..radius) {
+                for (z in -radius..radius) {
+                    val blockX = position3D.x + x
+                    val blockY = position3D.y + y
+                    val blockZ = position3D.z + z
+
+                    // Use getBlockAt for specific coordinates
+                    if (world.getBlockAt(blockX, blockY, blockZ).type == Material.END_PORTAL_FRAME) {
+                        return true
+                    }
+                }
+            }
+        }
+        return false
+    }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/WorldManipulationServiceBukkit.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/services/WorldManipulationServiceBukkit.kt
@@ -7,6 +7,7 @@ import dev.mizarc.bellclaims.infrastructure.adapters.bukkit.toLocation
 import org.bukkit.Bukkit
 import org.bukkit.Material
 import java.util.UUID
+import kotlin.math.abs
 
 class WorldManipulationServiceBukkit : WorldManipulationService {
     override fun breakWithoutItemDrop(worldId: UUID, position: Position3D): Boolean {
@@ -39,5 +40,25 @@ class WorldManipulationServiceBukkit : WorldManipulationService {
                     areaMaxZ <= borderMaxZ
 
         return isContained
+    }
+
+    override fun isOnEndPlatform(worldId: UUID, position3D: Position3D): Boolean {
+        val world = Bukkit.getWorld(worldId) ?: return false
+
+        // Filter to the end
+        if (world.environment != org.bukkit.World.Environment.THE_END) return false
+
+        // Get the bounds
+        val startX = 100
+        val startY = 49
+        val startZ = 0
+
+        val dx = abs(position3D.x - startX)
+        val dz = abs(position3D.z - startZ)
+        val dy = position3D.y - startY
+
+        // 5x5 horizontally centered on start
+        return dx <= 2 && dz <= 2 && dy in -1 .. 3
+
     }
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/MoveToolListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/MoveToolListener.kt
@@ -45,10 +45,17 @@ class MoveToolListener: Listener, KoinComponent {
                         event.player.uniqueId, LocalizationKeys.FEEDBACK_MOVE_TOOL_SUCCESS))
                         .color(TextColor.color(85, 255, 85)))
             }
-            is MoveClaimAnchorResult.InvalidPosition -> {
+            is MoveClaimAnchorResult.OutsiderBorder-> {
                 event.player.sendActionBar(
                     Component.text(localizationProvider.get(
                         playerId, LocalizationKeys.FEEDBACK_MOVE_TOOL_OUTSIDE_BORDER))
+                        .color(TextColor.color(255, 85, 85)))
+                event.isCancelled = true
+            }
+            is MoveClaimAnchorResult.InvalidPosition -> {
+                event.player.sendActionBar(
+                    Component.text(localizationProvider.get(
+                        playerId, LocalizationKeys.FEEDBACK_MOVE_TOOL_INVALID_POSITION))
                         .color(TextColor.color(255, 85, 85)))
                 event.isCancelled = true
             }

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/management/ClaimNamingMenu.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/menus/management/ClaimNamingMenu.kt
@@ -132,6 +132,19 @@ class ClaimNamingMenu(private val player: Player, private val menuNavigator: Men
                     bellItem.name(name)
                     gui.update()
                 }
+                is CreateClaimResult.InvalidPosition -> {
+                    val paperItem = ItemStack(Material.PAPER)
+                        .name(localizationProvider.get(playerId, LocalizationKeys.CREATION_CONDITION_INVALID_POSITION))
+                    val guiPaperItem = GuiItem(paperItem) { guiEvent ->
+                        secondPane.removeItem(0, 0)
+                        bellItem.name(name)
+                        isConfirming = true
+                        gui.update()
+                    }
+                    secondPane.addItem(guiPaperItem, 0, 0)
+                    bellItem.name(name)
+                    gui.update()
+                }
             }
         }
 

--- a/src/main/resources/lang/defaults/en.properties
+++ b/src/main/resources/lang/defaults/en.properties
@@ -48,6 +48,7 @@ feedback.destruction.success=Claim {0} has been destroyed
 # Move Tool
 feedback.move_tool.no_permission=You cannot move this claim bell
 feedback.move_tool.outside_border=Place this block within the claim borders
+feedback.move_tool.invalid_position=You cannot place the bell at this location
 feedback.move_tool.success=Claim position has been moved
 
 # Transfer

--- a/src/main/resources/lang/defaults/en.properties
+++ b/src/main/resources/lang/defaults/en.properties
@@ -70,6 +70,7 @@ creation_condition.existing=You already have a claim with that name.
 creation_condition.overlap=The resulting claim would overlap another claim.
 creation_condition.unnamed=Name cannot be blank.
 creation_condition.world_border=Too close to the world border to establish a claim.
+creation_condition.invalid_position=You cannot create a claim at this location.
 
 # Send Transfer Conditions
 send_transfer_condition.blocks=Player has insufficient claim blocks.


### PR DESCRIPTION
To prevent the bell from being deleted by these structures, there are now hard exclusion zones that prevent you from placing at these locations.