### PR TITLE
Fixed falling block being stopped by mob flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Visualisers showing up in all worlds instead of only the one where the claim exists in.
 - Player permissions can now be modified when the player is offline.
 - The button to Select all on player permissions works as intended.
+- Falling blocks don't fall when mob flag is active.
 
 ## [0.4.4]
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/WorldClaimProtectionListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/WorldClaimProtectionListener.kt
@@ -88,6 +88,7 @@ class WorldClaimProtectionListener: Listener, KoinComponent {
     @EventHandler
     fun onMobBlockChange(event: EntityChangeBlockEvent) {
         if (event.entity is Player) return
+        if (event.entity is FallingBlock) return
         val action = WorldActionType.MOB_DESTROY_BLOCK
         cancelIfDisallowed(event, event.block.location, action)
     }


### PR DESCRIPTION
Falling blocks should always work in claims. Because of incomplete checks, it was being stopped by the mob griefing flag.