### PR TITLE
Add new version support (1.21.11), Fix older 1.21 version support (1.21.0-1.21.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ## [0.5.0]
 
 ### Added
+- Support for Minecraft 1.21.11
 - Action bar popup text on entering and exiting claim.
 - New flag for villagers' ability to use doors.
 - Auto claim visualisation refreshes when moving between chunks, joining the server, and switching dimensions.
@@ -23,6 +24,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Player permissions can now be modified when the player is offline.
 - The button to Select all on player permissions works as intended.
 - Falling blocks don't fall when mob flag is active.
+- Versions 1.21.0-1.21.3 not working due to inventory framework.
 
 ## [0.4.4]
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,7 +65,8 @@ dependencies {
     implementation("com.zaxxer:HikariCP:5.1.0")
     implementation("co.aikar:acf-paper:0.5.1-SNAPSHOT")
     implementation("co.aikar:idb-core:1.0.0-SNAPSHOT")
-    implementation("com.github.mizarc:IF:0.11.4-d")
+    //implementation("com.github.mizarc:IF:0.11.4-d")
+    implementation("com.github.stefvanschie.inventoryframework:IF:0.11.6")
     implementation("io.insert-koin:koin-core:4.0.2")
     compileOnly("com.github.MilkBowl:VaultAPI:1.7") {
         exclude(group = "org.bukkit", module = "bukkit")
@@ -91,6 +92,6 @@ tasks.register<Copy>("deploy") {
     from(layout.buildDirectory.dir("libs"))
     println("Target deployment path: ${getProperty("plugin.server.path")}")
     into(getProperty("plugin.server.path"))
-    rename { fileName -> "${rootProject.name}-${version}.jar" }
+    rename { _ -> "${rootProject.name}-${version}.jar" }
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }

--- a/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
@@ -191,8 +191,6 @@ class BellClaims : JavaPlugin() {
             Class.forName("io.papermc.paper.event.player.PlayerClientLoadedWorldEvent")
             server.pluginManager.registerEvents(EditToolVisualisingListenerExtra(editToolVisualisingListener), this)
         } catch (e: ClassNotFoundException) {
-            // We are on an older version; PlayerClientLoadedWorldEvent logic is skipped.
-            // The fallback in EditToolVisualisingListener (the 5s timeout) will handle cleanup.
             logger.info("Skipping modern client-load events: Server version is older than 1.21.4.")
         }
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/BellClaims.kt
@@ -182,7 +182,20 @@ class BellClaims : JavaPlugin() {
         server.pluginManager.registerEvents(CloseInventoryListener(), this)
         server.pluginManager.registerEvents(EditToolListener(), this)
         server.pluginManager.registerEvents(ClaimEnterListener(), this)
-        server.pluginManager.registerEvents(EditToolVisualisingListener(this), this)
+
+        val editToolVisualisingListener = EditToolVisualisingListener(this)
+        server.pluginManager.registerEvents(editToolVisualisingListener, this)
+
+        // Try to register the modern "Extra" listener only if the class exists
+        try {
+            Class.forName("io.papermc.paper.event.player.PlayerClientLoadedWorldEvent")
+            server.pluginManager.registerEvents(EditToolVisualisingListenerExtra(editToolVisualisingListener), this)
+        } catch (e: ClassNotFoundException) {
+            // We are on an older version; PlayerClientLoadedWorldEvent logic is skipped.
+            // The fallback in EditToolVisualisingListener (the 5s timeout) will handle cleanup.
+            logger.info("Skipping modern client-load events: Server version is older than 1.21.4.")
+        }
+
         server.pluginManager.registerEvents(HarvestReplantListener(), this)
         server.pluginManager.registerEvents(MoveToolListener(), this)
         server.pluginManager.registerEvents(PartitionUpdateListener(), this)

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolVisualisingListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolVisualisingListener.kt
@@ -25,21 +25,11 @@ class EditToolVisualisingListener(private val plugin: JavaPlugin): Listener, Koi
     private val syncToolVisualization: SyncToolVisualization by inject()
 
     // Track players who've just loaded in so we can ignore spurious inventory events until they're fully in-game
-    private val initialisingPlayers: MutableSet<UUID> = ConcurrentHashMap.newKeySet()
+    internal val initialisingPlayers: MutableSet<UUID> = ConcurrentHashMap.newKeySet()
 
     @EventHandler
     fun onPlayerPreLogin(event: AsyncPlayerPreLoginEvent) {
         initialisingPlayers.add(event.uniqueId)
-    }
-
-    /**
-     * Triggers when the player joins the server.
-     */
-    @EventHandler
-    fun onPlayerJoin(event: PlayerClientLoadedWorldEvent) {
-        val player = event.player
-        handleAutoVisualisation(player)
-        initialisingPlayers.remove(player.uniqueId)
     }
 
     /**
@@ -102,7 +92,7 @@ class EditToolVisualisingListener(private val plugin: JavaPlugin): Listener, Koi
      * Visualise if the player isn't already holding the claim tool (e.g. swapping hands)
      * Also update the tracked set depending on whether the player holds the tool after the sync.
      */
-    private fun handleAutoVisualisation(player: Player) {
+    internal fun handleAutoVisualisation(player: Player) {
         val playerId = player.uniqueId
         val mainHand = player.inventory.itemInMainHand
         val offHand = player.inventory.itemInOffHand

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolVisualisingListenerExtra.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/EditToolVisualisingListenerExtra.kt
@@ -1,0 +1,19 @@
+package dev.mizarc.bellclaims.interaction.listeners
+
+import io.papermc.paper.event.player.PlayerClientLoadedWorldEvent
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.koin.core.component.KoinComponent
+
+class EditToolVisualisingListenerExtra(private val mainListener: EditToolVisualisingListener): Listener, KoinComponent {
+
+    /**
+     * Triggers when the player joins the server.
+     */
+    @EventHandler
+    fun onPlayerWorldSwitch(event: PlayerClientLoadedWorldEvent) {
+        val player = event.player
+        mainListener.handleAutoVisualisation(player)
+        mainListener.initialisingPlayers.remove(player.uniqueId)
+    }
+}


### PR DESCRIPTION
Due to inventory framework not being set up correctly and a new event being established, older version support broke. This re-implements support for these previous versions.

This also adds new support for 1.21.11