### PR TITLE
Claim tool removal additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Claim bells are now blocked from being created or moved into protected zones such as end portals and gateways.
 - The mob flag now protects players dropping cobwebs from the weaving effect.
 - New submenu for claim details. The primary icon in the management menu now shows the name, description, and location of claim.
+- Claim tool can now be removed from inventory by clicking out of inventory window with item on cursor.
 
 ### Changed
 - Optimised the visualisation checks with a pre-cache to ensure visualisation checks aren't unnecessarily run.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - The button to Select all on player permissions works as intended.
 - Falling blocks don't fall when mob flag is active.
 - Versions 1.21.0-1.21.3 not working due to inventory framework.
+- Claim tool not being removed from inventory on death.
 
 ## [0.4.4]
 

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ToolRemovalListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ToolRemovalListener.kt
@@ -134,13 +134,7 @@ class ToolRemovalListener : Listener, KoinComponent {
 
     @EventHandler
     fun onPlayerDeath(event: PlayerDeathEvent) {
-        val droppedItems = event.drops
-        val itemsToRemove = arrayListOf<ItemStack>()
-        for (droppedItem in droppedItems) {
-            if (isKeyItem(droppedItem)) {
-                itemsToRemove.add(droppedItem)
-            }
-        }
+        event.drops.removeIf { isKeyItem(it) }
     }
 
     private fun isKeyItem(itemStack: ItemStack): Boolean {

--- a/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ToolRemovalListener.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/interaction/listeners/ToolRemovalListener.kt
@@ -34,16 +34,22 @@ class ToolRemovalListener : Listener, KoinComponent {
 
     @EventHandler
     fun onMoveToInventory(event: InventoryClickEvent) {
-        // Cancel if item is in bottom
+        val itemStack = event.cursor
+        if (!isKeyItem(itemStack)) return
+
+        // Detect click outside of the inventory window
+        if (event.clickedInventory == null) {
+            event.view.setCursor(null)
+            return
+        }
+
+        // Cancel if item is in bottom (standard inventory)
         if (event.clickedInventory === event.view.bottomInventory) {
             return
         }
 
-        // Check if item is trying to be placed in top slot
-        val itemStack = event.cursor
-        if (isKeyItem(itemStack)) {
-            event.isCancelled = true
-        }
+        // Check if the item is trying to be placed in the top slot (Chests, Furnaces, etc)
+        event.isCancelled = true
     }
 
     @EventHandler


### PR DESCRIPTION
Claim tool can now be removed from inventory by clicking off inventory window with item in cursor.
Additional fix for removal on death.