### PR TITLE
Fix non-English character parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [0.5.1]
+
+### Fixed
+- Language system not working with non-English characters. Parser now utilises UTF-8.
+
 ## [0.5.0]
 
 ### Added

--- a/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/utilities/LocalizationProviderProperties.kt
+++ b/src/main/kotlin/dev/mizarc/bellclaims/infrastructure/utilities/LocalizationProviderProperties.kt
@@ -98,7 +98,7 @@ class LocalizationProviderProperties(private val config: MainConfig,
             val specificDefaultFile = File(defaultsFolder, "$locale.properties")
             if (specificDefaultFile.exists()) {
                 try {
-                    specificDefaultFile.inputStream().use { properties.load(it) }
+                    specificDefaultFile.reader(Charsets.UTF_8).use { properties.load(it) }
                     println("Loaded language: $locale")
                 } catch (_: Exception) {
                     println("Failed to load default language file for $locale")
@@ -109,7 +109,7 @@ class LocalizationProviderProperties(private val config: MainConfig,
             val overrideFile = File(overridesFolder, "$locale.properties")
             if (overrideFile.exists()) {
                 try {
-                    overrideFile.inputStream().use { properties.load(it) }
+                    overrideFile.reader(Charsets.UTF_8).use { properties.load(it) }
                     println("Loaded override language file: $locale")
                 } catch (_: Exception) {
                     println("Failed to load override language file for $locale")


### PR DESCRIPTION
Just had to switch the parser to utilise UTF- 8 in order to handle these characters correctly.